### PR TITLE
chore(squad): wire @copilot coding agent onto roster

### DIFF
--- a/.squad/team.md
+++ b/.squad/team.md
@@ -10,6 +10,8 @@
 
 ## Members
 
+<!-- copilot-auto-assign: true -->
+
 | Name | Role | Charter | Status |
 |------|------|---------|--------|
 | Lead | Team Lead and Architect | [charter](agents/lead/charter.md) | Active |
@@ -19,9 +21,27 @@
 | Burke | Companion-MCP Integration Engineer | [charter](agents/burke/charter.md) | Active |
 | Sentinel | Security and Read-Only Enforcement | [charter](agents/sentinel/charter.md) | Active |
 | Sage | Research and Documentation | [charter](agents/sage/charter.md) | Active |
+| @copilot | 🤖 GitHub Copilot Coding Agent | n/a (uses `.github/copilot-instructions.md`) | Active |
+
+### @copilot Capability Profile
+
+`@copilot` runs on GitHub-hosted compute and picks up issues assigned to it. It opens draft PRs from `copilot/*` branches.
+
+| Domain | Confidence | Notes |
+|---|---|---|
+| Python + FastMCP server code (small to medium scope) | 🟢 | Stack is locked per ADR-001. |
+| Pytest test authoring | 🟢 | Mocked Azure SDK, offline tests. |
+| Markdown docs, ADRs, READMEs | 🟢 | Honors AGENTS.md style rules (no em dashes). |
+| Copilot CLI extensions in `.github/extensions/` | 🟢 | Format documented in repo. |
+| Vendoring upstream files by commit SHA | 🟢 | Mechanical with clear acceptance criteria. |
+| KQL composition for ALZ scoring | 🟡 | Best when the underlying queries are already vendored. |
+| Reviewer gates and architecture verdicts | 🔴 | Lead retains these. Do not auto-assign reviewer issues. |
+| Multi-package refactors | 🔴 | Keep scope per-PR small. |
+
+Auto-assignment is enabled (see HTML comment above). The Lead may still re-route any issue by swapping `squad:*` labels.
 
 ## Project Context
 
 - **Project:** mcp-server-azure-architect, MCP server + Copilot CLI skills bundle for Azure architects
-- **Stack:** TBD (Python / TypeScript / .NET). Tracked as a Sage research issue.
+- **Stack:** Python 3.11+ with FastMCP (per ADR-001, accepted 2026-04-22). Hatchling build, ruff, mypy, pytest. Distribution via `uvx mcp-server-azure-architect`.
 - **Created:** 2026-04-22


### PR DESCRIPTION
Wires `@copilot` onto the Squad roster so we can run cloud-native when the human is offline.

## Changes
- Adds `@copilot` row to `.squad/team.md` Members table
- Sets `<!-- copilot-auto-assign: true -->` marker (honored by `squad-issue-assign.yml`)
- Documents capability profile (green / yellow / red) so Lead has a triage rubric
- Updates stale `Stack: TBD` line to Python 3.11+ + FastMCP per ADR-001

## Why
Branch protection blocks direct merges. The squad workflow is: open issue, label `squad:{member}`, agent picks it up, opens PR, Lead reviews, merge. With `@copilot` on the roster the entire cycle runs on GitHub-hosted compute without a local laptop.

## Validation
- AGENTS.md style: no em dashes
- Lead retains reviewer gates (capability profile marks reviews red)
