### PR TITLE
chore: add @copilot as second code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,10 @@
-* @martinopedal
+# CODEOWNERS — code owners who must review PRs touching matching paths.
+# See: https://docs.github.com/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+#
+# @copilot is added as a co-owner so the GitHub Copilot coding agent can
+# satisfy the code-owner review requirement on human-authored PRs and unblock
+# auto-merge. GitHub still prevents an author from approving their own PR,
+# so @copilot-authored PRs (the copilot/* branches) continue to require
+# review from a human owner.
+
+* @martinopedal @copilot


### PR DESCRIPTION
Allows @copilot to satisfy the CODEOWNERS gate on human-authored PRs so auto-merge can fire without manual approval. Per Martin's directive 2026-04-22: `allow @copilot to merge as needed`.

Caveat: GitHub does not let a PR author approve their own PR, so @copilot-authored PRs (the copilot/* branches: currently #26, #27) still need a human code owner.

Closes the second half of unblocking the cloud pipeline (the first half was enabling allow_auto_merge at the repo level, already done.)