### PR TITLE
chore(deps): tighten mcp and azure-identity version pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ authors = [
     { name = "Martin Opedal", email = "martinopedal@users.noreply.github.com" }
 ]
 dependencies = [
-    "mcp>=1.0.0",
-    "azure-identity>=1.15.0",
+    "mcp>=1.27.0,<2.0.0",
+    "azure-identity>=1.23.0,<2.0.0",
     "azure-mgmt-resourcegraph>=8.0.0",
 ]
 


### PR DESCRIPTION
## Rationale

Per Sentinel's wave-1 audit findings:
- **mcp**: Tightened from >=1.0.0 to >=1.27.0,<2.0.0 (was too loose for evolving spec)
- **azure-identity**: Tightened from >=1.15.0 to >=1.23.0,<2.0.0 (older versions had auth CVEs)

## Validation

All checks pass locally:
- ruff: clean
- mypy: no issues found
- pytest: 4/4 green
- cold-start profile: stable

Closes #32