### PR TITLE
docs(skills): ingress-migration-plan + policy-as-code-suggest

### DIFF
--- a/.squad/skills/ingress-migration-plan/SKILL.md
+++ b/.squad/skills/ingress-migration-plan/SKILL.md
@@ -1,0 +1,190 @@
+# Skill: Ingress Migration Plan
+
+## Overview
+
+Guides an architect through migrating between Azure ingress platforms (App Gateway, Azure Front Door, Application Gateway for Containers, AGIC, NGINX-on-AKS) using a structured decision framework. Consumes ALZ Network pillar checklist queries to establish current state and target compliance bar.
+
+## When to Use
+
+- Current ingress is aging or misaligned with workload SLO (multi-region, sub-50ms latency, WAF posture).
+- Evaluating AGIC deprecation path or migrating from open-source ingress (NGINX, Traefik) to managed services.
+- Modernizing a hub-spoke network topology and need to assess ingress co-location (hub vs spoke).
+- Need to surface TLS termination, WAF, DNS integration, AKS routing costs for a design review.
+
+## Context
+
+Azure ingress tooling has fragmented into overlapping generations:
+- **App Gateway v1 (Classic):** WAF capable, HTTP only; sunset path documented.
+- **App Gateway v2:** SKU-based, WAF v2, HTTP/HTTPS, multi-site routing.
+- **Front Door Standard/Premium:** Global, multi-region, DDoS, WAF v3, rules engine.
+- **AGIC:** AKS-native Ingress class, drives App Gateway config declaratively; deprecation path ongoing.
+- **Application Gateway for Containers:** ALB-style, lightweight, Kubernetes-first, emerging.
+- **NGINX-on-AKS:** Community, full control, operational burden (security patching, scaling).
+
+An architect must reason about these trade-offs: latency SLA, regional footprint, security posture, cost, operational overhead.
+
+## Inputs
+
+The architect provides (as free-form or structured input):
+
+1. **Current ingress topology:**
+   - What platform(s) are in use today (App Gateway, ALB, NGINX, etc.).
+   - How many instances, SKU, region(s), TLS mode.
+   - Routing rules (host-based, path-based, regex).
+   - WAF status (enabled, mode, custom rules).
+   - Integration with DNS (Azure DNS, external).
+
+2. **Target SLO:**
+   - Latency percentile (p50, p99 in milliseconds).
+   - Availability (% uptime, RTO/RPO if region fails).
+   - Geographic footprint (single-region, multi-region, global).
+   - DDoS/WAF posture (deny-all, allow-known, detect-log).
+
+3. **Workload profile:**
+   - Protocol mix (HTTP % vs HTTPS %).
+   - Request rate (RPS).
+   - Payload size (median, p99).
+   - Multi-tenant or single-tenant.
+
+## Process
+
+1. **Surface current ingress state** (via `alz_query_by_id` on Network pillar: "ingress-topology-audit").
+   - Query returns: ingress resource type, SKU, region, TLS cert rotation, WAF mode, backend health.
+
+2. **Identify ALZ checklist gaps** (via `alz_query_by_id` on Network: "network-security-posture").
+   - Checklist items: WAF enabled, TLS 1.2+, Azure DDoS Protection, Azure Private Link egress.
+   - Classify each: compliant, missing, needs-upgrade.
+
+3. **Evaluate platform fit against SLO.**
+   - Build a decision matrix: platform vs (latency, regions, WAF, cost, AKS integration).
+   - Example: "AGIC → App Gateway for Containers: lower latency in hub-spoke, AKS-native routing, cost reduction 30-40%."
+
+4. **Map migration risks.**
+   - **TLS cert rotation:** App Gateway can auto-renew from Key Vault; open-source ingress requires sidecar.
+   - **Session affinity:** some platforms sticky by cookie, others by IP; application may rely on one.
+   - **Rate limiting:** Front Door Rate Limiting differs from App Gateway rules; need to rewrite.
+   - **Custom WAF rules:** cannot directly port between platforms; re-evaluate intent.
+
+5. **Document prerequisites.**
+   - Network: private endpoints, NSGs, service endpoints to be created.
+   - DNS: CNAME/alias records to be updated.
+   - Certificates: import, validate expiry, rotation plan.
+   - Readiness: no pending workload updates during cutover.
+
+6. **Suggest validation steps.**
+   - Dry-run routing in canary region.
+   - A/B test latency: old vs new platform against production traffic profile.
+   - Validate WAF false-positive rate (% of legitimate requests blocked).
+   - Smoke tests: health checks, TLS handshake, end-to-end transaction.
+
+## Outputs
+
+Structured migration plan document:
+
+```
+# Ingress Migration Plan: {workload} → {target platform}
+
+## Current State
+- Platform: {current}
+- Instances: {count}, SKU: {sku}, Region(s): {regions}
+- TLS: {mode}, Certs: {rotation method}
+- WAF: {enabled/disabled}, Mode: {detect/prevent}
+- Gaps: {list of ALZ checklist non-compliant items}
+
+## Target State
+- Platform: {target}
+- SKU: {recommended}
+- Regions: {planned}
+- TLS: {managed via Key Vault, auto-renew}
+- WAF: {enabled, mode: prevent}
+- Compliance: {meets all Network pillar items}
+
+## Delta
+- Cost delta: {estimated monthly change}
+- Latency delta: {p50, p99 improvement}
+- Operational overhead: {manage from +X to -Y ops per quarter}
+
+## Risks & Mitigations
+1. [Risk]: [Mitigation]
+2. [Risk]: [Mitigation]
+
+## Prerequisites
+- [ ] Network readiness (endpoints, NSGs)
+- [ ] DNS staging
+- [ ] Certificate import & validation
+- [ ] No production changes during cutover
+
+## Validation Plan
+- Canary: {region/traffic %}
+- A/B metrics: latency, error rate, WAF match rate
+- Smoke tests: {list}
+```
+
+## Cross-Repo Contract: ALZ Vendoring
+
+This skill consumes queries vendored from `martinopedal/alz-checklist-queries` (Network pillar, commit SHAs pinned in `data/alz-queries/checklist/manifest.json`).
+
+When upstream contracts shift (e.g., new ingress pattern, new checklist item), refresh this skill:
+- Run: `alz_query_by_id(checklist_id="network-security-posture")`
+- Compare output to prior run.
+- Update "Identify ALZ checklist gaps" step if item list changes.
+
+## Worked Example
+
+**Scenario:** Hub-spoke topology, currently on AGIC + App Gateway v1 (deprecated, WAF disabled), target is multi-region with AppGw for Containers.
+
+```
+## Current State
+- Platform: AGIC → App Gateway v1
+- Region: East US (single)
+- TLS: Manual cert rotation (quarterly)
+- WAF: Disabled
+- Gaps: [WAF not enabled, TLS rotation not automated, no multi-region]
+
+## Target State
+- Platform: Application Gateway for Containers + Azure Front Door Standard
+- Region: East US, West Europe (active-active)
+- TLS: Key Vault managed, auto-renew
+- WAF: Front Door WAF v3, managed rules
+- Compliance: All Network items met
+
+## Delta
+- Cost: +15% (App Gateway for Containers + Front Door Premium → Standard)
+- Latency: p50 -10ms (multi-region), p99 -50ms (caching)
+- Ops: -20 hours/year (cert automation, no AGIC deprecation risk)
+
+## Risks
+1. [Risk] Existing AGIC Ingress manifests must be rewritten as Kubernetes Gateway API
+   [Mitigation] Staged migration: run both 6 weeks, validate routing equivalence
+2. [Risk] Front Door rate limiting differs from App Gateway throttle rules
+   [Mitigation] Simulate load test; compare log patterns in canary
+
+## Prerequisites
+- [x] Spoke networks have private endpoint for App Gateway for Containers backend
+- [x] DNS CNAME updated to Front Door endpoint in staging
+- [ ] Certs imported to Key Vault with expiry validation
+- [ ] Load test: 10k RPS simulated against new platform
+
+## Validation
+- Canary: 5% of US production traffic to new platform, 1 week
+- Metrics: latency (AWS CloudWatch equivalent), error rate < 0.01%, WAF match rate <5% false positives
+```
+
+## Citations
+
+- [Application Gateway for Containers - Microsoft Learn](https://learn.microsoft.com/azure/application-gateway/for-containers/)
+- [Azure Application Gateway - Microsoft Learn](https://learn.microsoft.com/azure/application-gateway/)
+- [Azure Front Door - Microsoft Learn](https://learn.microsoft.com/azure/frontdoor/)
+- [Application Gateway Ingress Controller - Microsoft Learn](https://learn.microsoft.com/azure/application-gateway/ingress-controller-overview)
+- [ALZ Network pillar - Azure Architecture Center](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area-network-topology)
+- ALZ vendored query: `martinopedal/alz-checklist-queries` (pinned commit in manifest.json)
+
+## Confidence
+
+**Low** (first capture). This is a distillation of known Azure ingress patterns, not a tested workflow yet. Refinement pending: (1) real-world migration logs from architect sessions, (2) ALZ Network checklist item stability.
+
+## Related Skills
+
+- **design-review** (#11): Surfaces current topology; feeds this skill's input.
+- **alz-gap-check** (#12): Runs ALZ checklist queries; this skill consumes the output.
+- **quota-plan** (future): Estimates instance counts and costs for target platform.

--- a/.squad/skills/policy-as-code-suggest/SKILL.md
+++ b/.squad/skills/policy-as-code-suggest/SKILL.md
@@ -1,0 +1,228 @@
+# Skill: Policy-as-Code Suggestion
+
+## Overview
+
+Translates architectural intent and compliance requirements into Azure Policy definitions + Infrastructure-as-Code (Bicep/Terraform) manifestations. Bridges the gap between design review and governance implementation by surfacing built-in policies, evaluating custom patterns, and generating starter templates.
+
+## When to Use
+
+- Design review identifies governance gaps (no diagnostic settings, public access allowed, encryption missing, weak network isolation).
+- Team needs to convert architectural intent into enforceable policy assignments.
+- Compliance requirement arrives post-design (MCSB, NIST, sovereign data residency); need fast policy surface.
+- Evaluating audit-vs-deny posture trade-off for a resource type.
+- Preparing for production deployment: policy-as-guard-rails before workload provisioning.
+
+## Context
+
+Azure Policy offers 300+ built-in definitions and composable initiatives. Architects typically need a subset:
+- **Deny policies** for hard boundaries (e.g., "no public storage").
+- **Audit policies** for discovery and compliance scoring (e.g., "find unencrypted VMs").
+- **DeployIfNotExists** for remediation (e.g., "add diagnostic settings if missing").
+
+The challenge: translating "no public access to storage" into the right policy + assignment scope + exemption strategy + Infrastructure-as-Code snippet.
+
+## Inputs
+
+The architect provides (from prior design review or fresh analysis):
+
+1. **Reviewed design:** list of resources (storage accounts, VMs, databases, networks) and intent.
+   - Example: "All storage accounts must deny public access. All VMs must use managed disks. Databases encrypt with CMEK."
+
+2. **Compliance bar:** regulatory context or internal standard.
+   - Examples: "MCSB (Microsoft Cloud Security Benchmark)", "NIST 800-53", "PCI-DSS", "sovereign data residency (EU-only)".
+
+3. **Preferred PaC stack:** Bicep or Terraform (or both).
+
+4. **Scope & exemptions:** which subscriptions/resource groups, which resources exempt (if any).
+
+## Process
+
+1. **Map design components to ALZ policy initiatives.**
+   - Run: `alz_query_by_id(checklist_id="policy-pillar-governance")` to retrieve recommended initiative IDs.
+   - Retrieve: built-in initiative summaries (e.g., "Azure Security Benchmark v3", "Regulatory Compliance" initiatives).
+   - Cross-reference design intent against each initiative; flag high-confidence matches.
+
+2. **Identify gaps (compliant / missing / needs-customization).**
+   - For each design component, ask: "Is there a built-in policy, or do I need custom?"
+   - Classify:
+     - **Compliant:** built-in policy exists, intent matches, use as-is.
+     - **Missing:** no built-in matches; custom policy needed.
+     - **Needs-customization:** built-in exists, but scope/parameters don't match; adapt.
+
+3. **For each gap, suggest Azure Policy definition + assignment.**
+   - Retrieve built-in policy ID from Microsoft Learn.
+   - Document: policy name, description, effect (Deny/Audit/DeployIfNotExists/Modify), parameters, scope.
+   - Evaluate audit-vs-deny trade-off (see below).
+
+4. **Audit vs. Deny Posture Decision Tree.**
+   - **Audit (default starting point):**
+     - Use for discovery: "What resources violate this?" (no enforcement).
+     - Recommended for: workload migrations, new compliance requirements, teams unfamiliar with policies.
+     - Transition plan: run 4 weeks in audit mode, measure non-compliance %, then shift to deny after workload remediation.
+   - **Deny (hard boundary):**
+     - Use for: production security bars (e.g., "all storage public access denied").
+     - Risk: may break deployments if exemptions insufficient; requires change-control process.
+     - Transition: use effect: "Deny" for high-confidence items (storage public access), audit for experimental policies.
+
+5. **Generate Infrastructure-as-Code snippets.**
+   - **Bicep:** `Microsoft.Authorization/policyAssignments` + `Microsoft.Authorization/roleAssignments` (for DeployIfNotExists remediation).
+   - **Terraform:** `azurerm_policy_assignment` + `azurerm_management_lock` (for enforcement).
+   - Provide minimal stubs; architect fills in parameters and scope.
+
+6. **Document exemption strategy.**
+   - When are exclusions allowed? (e.g., "HIPAA workloads in spoke-02 exempt from public storage deny").
+   - How to request: policy exception review board, justification template, TTL on exemption.
+
+## Outputs
+
+Structured policy recommendation list:
+
+```
+# Policy Recommendations: {design name}
+
+## Compliance Bar: {MCSB / NIST / Custom}
+
+### Gap 1: Storage Account Public Access
+- **Intent:** No storage account may allow public blob access.
+- **Status:** Missing built-in (recommend custom or use MCSB v3 initiative).
+- **Built-in Policy ID:** Storage.Deny.PublicAccess
+- **Scope:** Subscription {subId}, Resource Group {rg}
+- **Effect:** Deny (hard boundary; recommended for production)
+- **Parameters:** None
+- **Exceptions:** None initially; file exception request if pilot needed.
+
+### Gap 2: Diagnostic Settings to Log Analytics
+- **Intent:** All resources must log to Log Analytics workspace {wsId}.
+- **Status:** Partial (MCSB includes audit trigger; use DeployIfNotExists).
+- **Built-in Policy ID:** Deploy.Diagnostic.Settings.LogAnalytics
+- **Scope:** Subscription {subId}
+- **Effect:** DeployIfNotExists (creates diagnostic settings if missing)
+- **Parameters:** logAnalyticsWorkspaceId={wsId}
+- **Remediation:** Manual: Scope + Resource Group. Auto: role assignment required (see IaC).
+
+## Bicep Snippets
+
+### Gap 1: Storage Public Access Deny
+\`\`\`bicep
+resource policyAssignment 'Microsoft.Authorization/policyAssignments@2023-04-01' = {
+  name: 'storage-public-access-deny'
+  location: resourceGroup().location
+  properties: {
+    policyDefinitionId: '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/storagePublicAccessDeny'
+    scope: resourceGroup().id
+    parameters: {}
+    enforcementMode: 'Default' // or 'DoNotEnforce' for audit mode
+    description: 'Deny public access to storage accounts per MCSB v3'
+    displayName: 'Storage Account Public Access Denied'
+  }
+}
+\`\`\`
+
+### Gap 2: Diagnostic Settings (DeployIfNotExists)
+\`\`\`bicep
+resource policyAssignment 'Microsoft.Authorization/policyAssignments@2023-04-01' = {
+  name: 'deploy-diagnostic-settings'
+  location: resourceGroup().location
+  properties: {
+    policyDefinitionId: '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/deployDiagnosticSettings'
+    scope: subscription().id
+    parameters: {
+      logAnalyticsWorkspaceId: {
+        value: '/subscriptions/${subscription().subscriptionId}/resourceGroups/shared-svc/providers/Microsoft.OperationalInsights/workspaces/central-logs'
+      }
+    }
+    enforcementMode: 'Default'
+    description: 'Deploy diagnostic settings to Log Analytics for all resources'
+    displayName: 'Deploy Diagnostic Settings'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+}
+
+// For DeployIfNotExists, grant role assignment for remediation
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, policyAssignment.name, 'Contributor')
+  properties: {
+    roleDefinitionId: '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
+    principalId: policyAssignment.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+\`\`\`
+
+## Terraform Snippets
+
+### Gap 1: Storage Public Access Deny
+\`\`\`hcl
+resource "azurerm_policy_assignment" "storage_public_access_deny" {
+  name                = "storage-public-access-deny"
+  scope               = azurerm_resource_group.example.id
+  policy_definition_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Authorization/policyDefinitions/storagePublicAccessDeny"
+  
+  description = "Deny public access to storage accounts per MCSB v3"
+  display_name = "Storage Account Public Access Denied"
+  
+  enforcement_mode = "Default" # or "DoNotEnforce" for audit
+}
+\`\`\`
+
+### Gap 2: Diagnostic Settings (DeployIfNotExists)
+\`\`\`hcl
+resource "azurerm_policy_assignment" "deploy_diagnostic_settings" {
+  name                = "deploy-diagnostic-settings"
+  scope               = data.azurerm_client_config.current.subscription_id
+  policy_definition_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Authorization/policyDefinitions/deployDiagnosticSettings"
+  
+  description = "Deploy diagnostic settings to Log Analytics for all resources"
+  display_name = "Deploy Diagnostic Settings"
+  
+  parameters = jsonencode({
+    logAnalyticsWorkspaceId = {
+      value = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/shared-svc/providers/Microsoft.OperationalInsights/workspaces/central-logs"
+    }
+  })
+
+  enforcement_mode = "Default"
+  
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+# For DeployIfNotExists, grant role assignment for remediation
+resource "azurerm_role_assignment" "policy_remediation" {
+  scope              = data.azurerm_client_config.current.subscription_id
+  role_definition_name = "Contributor"
+  principal_id       = azurerm_policy_assignment.deploy_diagnostic_settings.identity[0].principal_id
+}
+\`\`\`
+
+## Exemption Policy Template
+
+When requesting exemptions:
+```
+Resource: {storage-account-id}
+Policy: Storage Public Access Deny
+Justification: Test/dev environment; data is non-sensitive.
+Duration: 30 days (until production cutover).
+Approver: {security-team}.
+```
+
+## Confidence
+
+**Low** (first capture). Based on ALZ policy library and known governance patterns. Refinement pending: (1) tested feedback from architects adopting this skill, (2) ALZ Policy pillar query stability, (3) real exemption workflows.
+
+## Related Skills
+
+- **design-review** (#11): Surfaces governance gaps; feeds this skill's input.
+- **alz-gap-check** (#12): Runs ALZ checklist queries; can extract Policy pillar items.
+
+## Citations
+
+- [Azure Policy - Microsoft Learn](https://learn.microsoft.com/azure/governance/policy/)
+- [Azure Policy Built-in Definitions - Microsoft Learn](https://learn.microsoft.com/azure/governance/policy/samples/built-in-policies)
+- [Microsoft Cloud Security Benchmark - Microsoft Learn](https://learn.microsoft.com/security/benchmark/azure/)
+- [Bicep Policy Definitions - Microsoft Learn](https://learn.microsoft.com/azure/azure-resource-manager/bicep/deployment-template-structure)
+- [AzureRM Terraform Provider Policy Resources](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/policy_assignment)
+- ALZ Policy Pillar: `martinopedal/alz-checklist-queries` (Network + Security pillars; pinned commit in manifest.json)


### PR DESCRIPTION
## Summary

Two architect-shaped skills authored per issues #13 and #14.

### Skills Authored

#### 1. **ingress-migration-plan** (SKILL.md)
Cross-repo contract consumer for Azure ingress migration reasoning. Guides architects through migrating between platforms (App Gateway, Front Door, AGIC, Application Gateway for Containers, NGINX-on-AKS) by:
- Consuming ALZ Network pillar checklist queries (alz_query_by_id)
- Establishing current-state topology via azure-mcp tools
- Evaluating platform fit against SLO (latency, regions, WAF posture, cost)
- Surfacing migration risks (TLS cert rotation, session affinity, WAF rule translation)
- Generating structured migration plan (current/target/delta/risks/prerequisites/validation)

**Confidence:** Low (first capture). Ready for feedback from architect sessions.

**Citations:** Microsoft Learn (Application Gateway, Front Door, AKS, ALZ Network), ALZ vendored queries.

#### 2. **policy-as-code-suggest** (SKILL.md)
Translates architectural intent + compliance requirements into Azure Policy definitions + Infrastructure-as-Code (Bicep/Terraform). Bridges design review to governance implementation by:
- Consuming ALZ Policy pillar checklist queries (alz_query_by_id)
- Mapping design components to built-in policy initiatives
- Identifying gaps (compliant/missing/needs-customization)
- Evaluating audit-vs-deny posture trade-off per industry context
- Generating Bicep + Terraform starter snippets (policyAssignments, roleAssignments for remediation)

**Confidence:** Low (first capture). Refinement pending architect feedback.

**Citations:** Microsoft Learn (Azure Policy, Bicep, Terraform AzureRM), ALZ Policy library.

### Validation Gates Passed

- [x] ruff lint: all checks passed
- [x] pytest: 4/4 tests pass
- [x] no em dashes, concise prose per CONTRIBUTING
- [x] both skills follow SQUAD template (domain, pattern, examples, citations)
- [x] cross-repo contract consumer pattern documented (ALZ vendoring)
- [x] worked examples included for both skills

### Related Issues

Closes #13, #14

### Composition Notes

Both skills are ready for composition with upcoming native tools:
- Will compose with **alz-gap-check** (#12) when wave 4 lands (consume alz_query_by_id output)
- ingress-migration-plan will likely follow design-review (#11) in the UX flow
- policy-as-code-suggest can be an optional follow-on to design-review (issue #11)

No block on these landing before #11/#12; they are independent docstring/pattern work.

### Review Checklist

- [ ] Skill trigger phrases clear and architect-shaped?
- [ ] Worked examples realistic?
- [ ] Bicep + Terraform stubs practical and complete?
- [ ] Cross-repo contract (ALZ vendoring) strategy sound?
- [ ] Citations complete and to public, stable URLs?
