### PR TITLE
feat(server): native alz_query_by_id tool

### DIFF
--- a/.squad/agents/forge/history.md
+++ b/.squad/agents/forge/history.md
@@ -165,3 +165,21 @@ Wave 2 complete: foundation (#22, #23, #26, #27, #33, #34) all on main. Decision
 **ADR-003 layer 1 implementation assigned (issue #7).** Sentinel's defense-in-depth model ratified. Forge now owns `.github/scripts/check_readonly.py` implementation (AST-based import allowlist, scans `src/` for mutation methods). Blocker for v0.1 release. Threat model E1 threat (mutation method exposure) justifies this CI gate. Timeline: implementation deferred to wave 4; target merge before beta validation.
 
 **ADR-003 & threat model inform future tool PRs.** CODEOWNERS convention (naming: `_get_*`, `_list_*`, `_query_*` allowed) now applied to all tool implementations. Runtime guard (layer 3, aspirational for v0.2) documented in ADR-003; complexity deferred but pattern established. ADR-004 (companion bar) + threat model (supply chain risk) frame issue #39 (native pricing tools) evaluation.
+
+## 2026-05-12T13:30:00Z — PR #45: alz_query_by_id native tool (closes #9)
+
+First substantive native tool shipped. End-to-end: stdlib loader + FastMCP tool registration + tests + wheel packaging.
+
+**PR:** #45 `feat(server): native alz_query_by_id tool with vendored loader`
+**Closes:** #9
+**Validation:** ruff clean, mypy strict clean, pytest 13/13, cold-start -99ms vs baseline (within variance band; under +50ms budget).
+
+### Learnings
+
+- **Native tool module pattern.** Place the data-backed loader in its own module under `src/mcp_server_azure_architect/` (e.g. `alz_queries.py`), pure stdlib where possible, with a lazy module-level cache (`_X = None` + `_get_x()` getter + `reset_cache()` for tests). Tool registration in `server.py` stays a thin `@mcp.tool()` wrapper that calls into the loader. This keeps cold-start unaffected (sub-ms parse cost) and preserves the read-only invariant by construction (no Azure SDK in the data path).
+- **Lazy load > eager load for cold-start.** Importing my new module added zero measurable overhead because the manifest is only read on first call. Eager parse at import time would have added ~5-15ms of JSON + file IO.
+- **Wheel packaging for vendored data.** Hatchling's `[tool.hatch.build.targets.wheel.force-include]` is the right hook to ship `data/alz-queries/` inside the wheel. Loader probes both locations (wheel force-include path under the package, and the editable / source-checkout path at the repo root) so the same code works for `pip install -e .` and a built wheel.
+- **TypedDict + FastMCP schema gotcha.** Returning `dict(typed_dict_instance)` in a function annotated `-> dict[str, str]` fails mypy strict because TypedDict's `__getitem__` returns `object`. Use a comprehension (`{k: str(v) for k, v in record.items()}`) at the boundary to satisfy the strict type contract.
+- **Async tool roundtrip test.** With `asyncio_mode = "auto"` in `pyproject.toml`, `async def test_*` works without decorators. Use `await mcp._tool_manager.call_tool(name, args)` to validate JSON Schema dispatch end-to-end (catches schema mismatches that the synchronous direct-call test misses).
+- **Confused-deputy doesn't apply when input is an allowlist key.** `checklist_id` is matched against vendored data; there's no Azure scope to authorize against, so Sentinel's S1/E1 mitigation isn't needed for this tool. Documented this in the module docstring so future tool authors who do take `subscription_id` know to apply `validate_caller_scope()`.
+- **Sibling worktree install collision.** A concurrent Forge sibling on `C:\git\mcp-server-azure-architect-pr39` has the same package installed editable to that path. `pip install -e .` from any worktree replaces the global pointer, so concurrent agents stomp each other. Workaround: re-run `pip install -e . --force-reinstall --no-deps` immediately before any test run if the sibling has touched the install in between. Long-term: move to per-agent venvs in worktrees.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,6 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"data/alz-queries" = "mcp_server_azure_architect/_data/alz-queries"

--- a/src/mcp_server_azure_architect/alz_queries.py
+++ b/src/mcp_server_azure_architect/alz_queries.py
@@ -1,0 +1,169 @@
+# READ-ONLY: this module performs static lookups against vendored data; no
+# Azure or filesystem writes. Per ADR-003, native tools backed by this loader
+# expose the `_query_*` verb pattern and never construct an Azure SDK client.
+"""Vendored ALZ checklist query loader.
+
+Design notes (Forge, wave 4):
+
+* **Pure stdlib.** Only `json` and `pathlib` are imported. No Azure SDK, no
+  httpx, no Pydantic. This keeps cold-start overhead at near zero (the module
+  loads in under a millisecond) and preserves the read-only invariant by
+  construction.
+* **Lazy parse.** The manifest is parsed on first call and cached in a
+  module-level singleton. Importing this module does not touch the filesystem.
+* **Source of truth.** Layout follows ADR-002 / PR #27. The vendored snapshot
+  lives at `data/alz-queries/` with `manifest.json` indexing checklist IDs to
+  `.kql` files. Atlas owns the data; this module is a read-only consumer.
+* **Confused-deputy mitigation (per Sentinel threat model, S1/E1).** The only
+  caller-supplied input is `checklist_id`, which is matched against the
+  vendored allowlist. There is no `subscription_id` surface here, so no
+  Azure-scoped authorization decision is delegated to the caller. Future tools
+  that take a `subscription_id` MUST validate caller scope separately.
+* **Install layouts.** The loader resolves the data root in two locations to
+  cover both `pip install -e .` (data sits at the repo root) and a built wheel
+  (force-included under the package as `_data/alz-queries`). See
+  `[tool.hatch.build.targets.wheel.force-include]` in `pyproject.toml`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TypedDict
+
+_MANIFEST_NAME = "manifest.json"
+_MAX_AVAILABLE_IDS_IN_ERROR = 10
+_DATA_PREFIX = ("data", "alz-queries")
+
+
+class QueryRecord(TypedDict):
+    """Return shape for a single vendored ALZ query lookup."""
+
+    checklist_id: str
+    kql: str
+    pillar: str
+    source_repo: str
+    source_commit: str
+    source_ref: str
+    source_file: str
+    vendored_at: str
+    vendored_path: str
+    citation: str
+
+
+def _resolve_data_root() -> Path:
+    """Locate the vendored ALZ data directory.
+
+    Tries the wheel-install location first (force-included under the package)
+    then falls back to the editable / source-checkout layout (repo root).
+    """
+    package_dir = Path(__file__).resolve().parent
+
+    wheel_path = package_dir / "_data" / "alz-queries"
+    if (wheel_path / _MANIFEST_NAME).is_file():
+        return wheel_path
+
+    repo_path = package_dir.parent.parent / "data" / "alz-queries"
+    if (repo_path / _MANIFEST_NAME).is_file():
+        return repo_path
+
+    raise FileNotFoundError(
+        "ALZ query manifest not found. Looked in "
+        f"{wheel_path} and {repo_path}."
+    )
+
+
+def _build_index(data_root: Path) -> dict[str, QueryRecord]:
+    """Parse the manifest and build the checklist_id -> QueryRecord index."""
+    manifest_path = data_root / _MANIFEST_NAME
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    index: dict[str, QueryRecord] = {}
+    for source in raw.get("sources", []):
+        repo = str(source["repo"])
+        commit = str(source["commit_sha"])
+        ref = str(source.get("ref", f"commit:{commit}"))
+        vendored_at = str(source.get("vendored_at", ""))
+        subset = source.get("subset", {})
+        source_file = str(subset.get("source_file", ""))
+        files = subset.get("files", [])
+
+        for relative_path in files:
+            parts = Path(relative_path).parts
+            if parts[: len(_DATA_PREFIX)] == _DATA_PREFIX:
+                inside = Path(*parts[len(_DATA_PREFIX) :])
+            else:
+                inside = Path(relative_path)
+            kql_path = data_root / inside
+
+            checklist_id = kql_path.stem
+            pillar = kql_path.parent.name
+            kql_text = kql_path.read_text(encoding="utf-8").strip()
+            citation = (
+                f"{repo}@{commit} ({source_file}) checklist_id={checklist_id}"
+            )
+
+            index[checklist_id] = QueryRecord(
+                checklist_id=checklist_id,
+                kql=kql_text,
+                pillar=pillar,
+                source_repo=repo,
+                source_commit=commit,
+                source_ref=ref,
+                source_file=source_file,
+                vendored_at=vendored_at,
+                vendored_path=str(Path(relative_path).as_posix()),
+                citation=citation,
+            )
+
+    return index
+
+
+_INDEX: dict[str, QueryRecord] | None = None
+
+
+def _get_index() -> dict[str, QueryRecord]:
+    """Return the parsed manifest index, building it on first call."""
+    global _INDEX
+    if _INDEX is None:
+        _INDEX = _build_index(_resolve_data_root())
+    return _INDEX
+
+
+def list_query_ids() -> list[str]:
+    """Return the sorted list of vendored checklist IDs.
+
+    Useful for diagnostics and for future tools that enumerate the catalog.
+    """
+    return sorted(_get_index().keys())
+
+
+def get_query(checklist_id: str) -> QueryRecord:
+    """Return the vendored query record for a checklist ID.
+
+    Raises:
+        LookupError: if the ID is not in the vendored allowlist. The error
+            message includes a capped sample of available IDs to aid recovery
+            without dumping the full catalog.
+    """
+    index = _get_index()
+    record = index.get(checklist_id)
+    if record is None:
+        available = sorted(index.keys())
+        sample = available[:_MAX_AVAILABLE_IDS_IN_ERROR]
+        suffix = (
+            f" (showing first {_MAX_AVAILABLE_IDS_IN_ERROR} of {len(available)})"
+            if len(available) > _MAX_AVAILABLE_IDS_IN_ERROR
+            else ""
+        )
+        raise LookupError(
+            f"checklist_id {checklist_id!r} not found in vendored ALZ "
+            f"snapshot. Available: {sample}{suffix}."
+        )
+    return record
+
+
+def reset_cache() -> None:
+    """Clear the cached manifest index. Intended for tests."""
+    global _INDEX
+    _INDEX = None

--- a/src/mcp_server_azure_architect/server.py
+++ b/src/mcp_server_azure_architect/server.py
@@ -3,6 +3,7 @@
 from mcp.server.fastmcp import FastMCP
 
 from mcp_server_azure_architect import __version__
+from mcp_server_azure_architect.alz_queries import get_query
 
 mcp = FastMCP("azure-architect")
 
@@ -18,3 +19,31 @@ def health_check() -> dict[str, str]:
         "status": "ok",
         "version": __version__,
     }
+
+
+@mcp.tool()
+def alz_query_by_id(checklist_id: str) -> dict[str, str]:
+    """Look up a vendored Azure Landing Zone (ALZ) checklist query by ID.
+
+    Returns the KQL query text plus source metadata (repo, commit SHA, ref,
+    citation) so the caller can run the query against Azure Resource Graph
+    and reference the upstream ALZ checklist item.
+
+    Read-only: this tool performs a static lookup against the vendored ALZ
+    snapshot under `data/alz-queries/`. It does not call Azure and does not
+    accept a subscription ID, so there is no confused-deputy surface here.
+
+    Args:
+        checklist_id: The ALZ checklist item ID (matches the vendored
+            `.kql` filename stem).
+
+    Returns:
+        A dictionary with `checklist_id`, `kql`, `pillar`, `source_repo`,
+        `source_commit`, `source_ref`, `source_file`, `vendored_at`,
+        `vendored_path`, and `citation`.
+
+    Raises:
+        LookupError: if the checklist ID is not in the vendored snapshot.
+    """
+    record = get_query(checklist_id)
+    return {key: str(value) for key, value in record.items()}

--- a/tests/test_alz_queries.py
+++ b/tests/test_alz_queries.py
@@ -1,0 +1,126 @@
+"""Tests for the vendored ALZ query loader and the alz_query_by_id tool."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from mcp_server_azure_architect import alz_queries
+from mcp_server_azure_architect.server import alz_query_by_id, mcp
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "data" / "alz-queries" / "manifest.json"
+
+
+def _known_checklist_id() -> str:
+    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return str(raw["sources"][0]["subset"]["checklist_ids"][0])
+
+
+def test_load_manifest_smoke() -> None:
+    """Manifest loads cleanly and the cache is populated on first call."""
+    alz_queries.reset_cache()
+    ids = alz_queries.list_query_ids()
+    assert isinstance(ids, list)
+    assert ids, "vendored snapshot should expose at least one checklist ID"
+    assert all(isinstance(item, str) for item in ids)
+
+
+def test_get_query_known_id() -> None:
+    """A known checklist ID returns a record with non-empty KQL and citation."""
+    checklist_id = _known_checklist_id()
+    record = alz_queries.get_query(checklist_id)
+
+    assert record["checklist_id"] == checklist_id
+    assert record["kql"].strip(), "KQL body must be non-empty"
+    assert record["source_repo"], "source_repo must be populated"
+    assert record["source_commit"], "source_commit must be populated"
+    assert record["citation"].startswith(record["source_repo"])
+    assert checklist_id in record["citation"]
+    assert record["pillar"] in {"checklist", "graph"}
+
+
+def test_get_query_unknown_id_raises_lookup_error() -> None:
+    """Unknown IDs surface a LookupError with a helpful message."""
+    with pytest.raises(LookupError) as excinfo:
+        alz_queries.get_query("not-a-real-checklist-id")
+
+    msg = str(excinfo.value)
+    assert "not-a-real-checklist-id" in msg
+    assert "Available" in msg
+
+
+def test_list_query_ids_returns_strings() -> None:
+    """list_query_ids returns a sorted list of unique string IDs."""
+    ids = alz_queries.list_query_ids()
+    assert ids == sorted(ids)
+    assert len(ids) == len(set(ids))
+
+
+def test_loader_does_not_import_azure_sdk() -> None:
+    """Importing the loader must not pull in the Azure SDK (cold-start guard)."""
+    for name in list(sys.modules):
+        if name.startswith(("azure.identity", "azure.mgmt", "azure.core")):
+            sys.modules.pop(name, None)
+    sys.modules.pop("mcp_server_azure_architect.alz_queries", None)
+
+    import mcp_server_azure_architect.alz_queries  # noqa: F401
+
+    leaked = [
+        name
+        for name in sys.modules
+        if name.startswith(("azure.identity", "azure.mgmt"))
+    ]
+    assert leaked == [], f"loader leaked Azure SDK imports: {leaked}"
+
+
+def test_alz_query_by_id_tool_registered_with_schema() -> None:
+    """FastMCP registers alz_query_by_id with the expected JSON Schema."""
+    tools = mcp._tool_manager.list_tools()
+    tool = next((t for t in tools if t.name == "alz_query_by_id"), None)
+
+    assert tool is not None, "alz_query_by_id should be registered"
+    assert tool.description is not None
+    assert "ALZ" in tool.description or "Azure Landing Zone" in tool.description
+
+    schema = tool.parameters
+    assert schema["type"] == "object"
+    assert "checklist_id" in schema["properties"]
+    assert schema["properties"]["checklist_id"]["type"] == "string"
+    assert "checklist_id" in schema.get("required", [])
+
+
+def test_alz_query_by_id_function_returns_record() -> None:
+    """Direct invocation returns a dict with the expected keys."""
+    checklist_id = _known_checklist_id()
+    result = alz_query_by_id(checklist_id)
+
+    assert isinstance(result, dict)
+    for key in ("checklist_id", "kql", "source_repo", "source_commit", "citation"):
+        assert key in result, f"missing key {key} in tool output"
+    assert result["checklist_id"] == checklist_id
+
+
+async def test_alz_query_by_id_invocation_via_mcp() -> None:
+    """End-to-end roundtrip through FastMCP's tool dispatcher."""
+    checklist_id = _known_checklist_id()
+    result = await mcp._tool_manager.call_tool(
+        "alz_query_by_id", {"checklist_id": checklist_id}
+    )
+
+    assert isinstance(result, dict)
+    assert result["checklist_id"] == checklist_id
+    assert result["kql"].strip()
+
+
+async def test_alz_query_by_id_unknown_id_via_mcp_raises() -> None:
+    """Unknown IDs surface as errors through the MCP dispatcher too."""
+    with pytest.raises(Exception) as excinfo:
+        await mcp._tool_manager.call_tool(
+            "alz_query_by_id", {"checklist_id": "definitely-not-a-real-id"}
+        )
+
+    assert "definitely-not-a-real-id" in str(excinfo.value)


### PR DESCRIPTION
## Summary

Implements the first substantive native tool: `alz_query_by_id`. Looks up a vendored ALZ checklist query by its checklist ID and returns the KQL plus full source citation (repo, commit SHA, ref, source file, vendored timestamp).

Closes #9.

## Design choices

* **Pure stdlib loader.** `src/mcp_server_azure_architect/alz_queries.py` uses only `json` + `pathlib`. No Azure SDK, no httpx, no Pydantic. Keeps cold-start clean and preserves the read-only invariant by construction.
* **Lazy parse.** Manifest is parsed on first call and cached in a module-level singleton. Importing the module does not touch the filesystem.
* **Wheel + editable install both supported.** Loader resolves the data root in two locations: force-included wheel path (`_data/alz-queries` under the package, configured in `pyproject.toml`) and the editable / source-checkout path (`data/alz-queries` at the repo root).
* **Read-only by design (ADR-003).** Tool name follows the `_query_*` lookup verb pattern. Top-of-file marker comment: `# READ-ONLY: this module performs static lookups against vendored data; no Azure or filesystem writes.`
* **Confused-deputy mitigation (Sentinel threat model, S1/E1).** The only caller-supplied input is `checklist_id`, matched against the vendored allowlist. There is no `subscription_id` surface, so no Azure-scoped authorization decision is delegated to the caller. Documented in the module docstring for future authors.
* **Friendly errors.** Unknown IDs raise `LookupError` with a capped sample of available IDs (max 10) to aid recovery without dumping the full catalog.

## Data shape (per ADR-002)

Reads `data/alz-queries/manifest.json` (Atlas's domain, untouched). Indexes the four checklist IDs currently vendored from `martinopedal/alz-checklist-queries` (commit `e7641be`) and `martinopedal/alz-graph-queries` (commit `8a3fdda`).

## Validation gates

| Gate | Result |
|---|---|
| `ruff check .` | clean |
| `mypy src tests` | clean (9 source files, strict mode) |
| `pytest -q` | **13 passed** (4 baseline + 9 new) |
| Cold-start | **-99ms** vs baseline median (Python 3.14, n=10, warmed) |

Cold-start variance is large (1191-1837 ms range), so the negative delta is within noise. The new module is pure stdlib + lazy parse, so the real overhead is sub-millisecond. Comfortably under the +50 ms budget.

## Test coverage

* `test_load_manifest_smoke` - manifest loads, IDs are populated
* `test_get_query_known_id` - happy path: KQL non-empty, citation includes repo + checklist ID
* `test_get_query_unknown_id_raises_lookup_error` - friendly error
* `test_list_query_ids_returns_strings` - sorted, unique
* `test_loader_does_not_import_azure_sdk` - cold-start + read-only invariant guard
* `test_alz_query_by_id_tool_registered_with_schema` - FastMCP introspection: `checklist_id: string` required
* `test_alz_query_by_id_function_returns_record` - direct invocation
* `test_alz_query_by_id_invocation_via_mcp` - async roundtrip through `ToolManager.call_tool`
* `test_alz_query_by_id_unknown_id_via_mcp_raises` - async error path

## References

* ADR-002 (data layer / vendoring policy)
* ADR-003 (read-only enforcement, `_query_*` naming convention)
* Sentinel threat model S1/E1 (confused-deputy)
* Issue #9
