### PR TITLE
feat(server): native Azure retail pricing tools (lookup, compare)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "mcp>=1.27.0,<2.0.0",
     "azure-identity>=1.23.0,<2.0.0",
     "azure-mgmt-resourcegraph>=8.0.0",
+    "httpx>=0.27.0,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/mcp_server_azure_architect/pricing.py
+++ b/src/mcp_server_azure_architect/pricing.py
@@ -1,0 +1,356 @@
+# READ-ONLY: this module performs HTTP GET against the public Azure Retail Prices API;
+# no auth, no Azure SDK, no writes.
+"""Native Azure retail pricing lookup tools.
+
+Calls the public Azure Retail Prices API (https://prices.azure.com/api/retail/prices).
+No authentication required. OData filter syntax. Paginated via NextPageLink.
+
+Read-only by design (ADR-003): only HTTP GET against a public Microsoft endpoint.
+
+Caveats surfaced in tool docstrings:
+- Retail prices only. No EA, CSP, or private rate cards.
+- USD default currency. The currencyCode parameter is forwarded to the API.
+- No real-time freshness SLA from Microsoft.
+- Reservation discounts only where Microsoft publishes them in the meter.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    import httpx
+
+PRICING_ENDPOINT = "https://prices.azure.com/api/retail/prices"
+
+# 24-hour TTL per issue #39 spec. Key = OData filter string. Value = (expiry_ts, items).
+_CACHE_TTL_SECONDS = 24 * 60 * 60
+_CACHE: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+
+# Defensive cap: max pages followed via NextPageLink. Each page is up to 1000 items.
+# Five pages tolerates 5000 SKU rows for a single filter, which is well above any
+# realistic single-SKU lookup. Higher values risk runaway requests on broad filters.
+_MAX_PAGES = 5
+
+# Soft cap on number of SKUs that pricing_compare_skus accepts in one call.
+_COMPARE_MAX_SKUS = 10
+
+
+def _get_client() -> httpx.Client:
+    """Lazily import httpx and construct a Client.
+
+    Lazy import keeps cold-start budget clean: httpx is not loaded at server module
+    import time, only when a pricing tool is actually invoked.
+    """
+    import httpx
+
+    return httpx.Client(timeout=30.0, follow_redirects=True)
+
+
+def _escape_odata_value(value: str) -> str:
+    """Escape a string for safe inclusion inside an OData single-quoted literal.
+
+    OData escapes single quotes by doubling them. Reference:
+    https://learn.microsoft.com/odata/concepts/uri-conventions#literals
+    """
+    return value.replace("'", "''")
+
+
+def _normalize_term(term: str) -> tuple[str, str | None]:
+    """Map a friendly term ('ondemand', '1yr', '3yr') to API filter values.
+
+    Returns:
+        (price_type, reservation_term) where reservation_term is None for ondemand.
+    """
+    t = term.lower().strip()
+    if t in ("ondemand", "consumption", "payg", "on-demand"):
+        return "Consumption", None
+    if t in ("1yr", "1y", "1year", "1 year"):
+        return "Reservation", "1 Year"
+    if t in ("3yr", "3y", "3year", "3 years", "3 year"):
+        return "Reservation", "3 Years"
+    raise ValueError(
+        f"Unknown term '{term}'. Expected one of: 'ondemand', '1yr', '3yr'."
+    )
+
+
+def _build_filter(sku: str, region: str, term: str) -> str:
+    """Build an OData $filter string for a single-SKU lookup.
+
+    The Retail Prices API is permissive about whether `sku` is the friendly
+    `skuName` ('D2s v5') or the ARM-style `armSkuName` ('Standard_D2s_v5'). Match
+    on `armSkuName` first because it is unambiguous; if the caller supplies a
+    friendly name without the 'Standard_' prefix, also try `skuName` via OR.
+    """
+    sku_esc = _escape_odata_value(sku)
+    region_esc = _escape_odata_value(region)
+    price_type, reservation_term = _normalize_term(term)
+
+    sku_clause = (
+        f"(armSkuName eq '{sku_esc}' or skuName eq '{sku_esc}')"
+    )
+    parts = [
+        sku_clause,
+        f"armRegionName eq '{region_esc}'",
+        f"priceType eq '{price_type}'",
+    ]
+    if reservation_term is not None:
+        rt_esc = _escape_odata_value(reservation_term)
+        parts.append(f"reservationTerm eq '{rt_esc}'")
+
+    return " and ".join(parts)
+
+
+def _cache_key(odata_filter: str, currency: str) -> str:
+    return f"{currency}|{odata_filter}"
+
+
+def _cache_get(key: str) -> list[dict[str, Any]] | None:
+    entry = _CACHE.get(key)
+    if entry is None:
+        return None
+    expiry, items = entry
+    if time.time() >= expiry:
+        _CACHE.pop(key, None)
+        return None
+    return items
+
+
+def _cache_put(key: str, items: list[dict[str, Any]]) -> None:
+    _CACHE[key] = (time.time() + _CACHE_TTL_SECONDS, items)
+
+
+def _fetch_all_pages(odata_filter: str, currency: str) -> list[dict[str, Any]]:
+    """Fetch every page of results for the given filter, capped at _MAX_PAGES.
+
+    Returns combined Items across pages.
+    """
+    items: list[dict[str, Any]] = []
+    params: dict[str, str] | None = {
+        "$filter": odata_filter,
+        "currencyCode": currency,
+    }
+    url: str = PRICING_ENDPOINT
+    pages = 0
+
+    with _get_client() as client:
+        while url and pages < _MAX_PAGES:
+            response = client.get(url, params=params)
+            response.raise_for_status()
+            payload = response.json()
+            page_items = payload.get("Items", []) or []
+            items.extend(page_items)
+            next_link = payload.get("NextPageLink")
+            if not next_link:
+                break
+            url = next_link
+            params = None
+            pages += 1
+
+    return items
+
+
+def _fetch_with_cache(odata_filter: str, currency: str) -> list[dict[str, Any]]:
+    key = _cache_key(odata_filter, currency)
+    cached = _cache_get(key)
+    if cached is not None:
+        return cached
+    items = _fetch_all_pages(odata_filter, currency)
+    _cache_put(key, items)
+    return items
+
+
+def _shape_item(raw: dict[str, Any]) -> dict[str, Any]:
+    """Project the raw API record into a stable, documented shape."""
+    return {
+        "retail_price": raw.get("retailPrice"),
+        "unit_price": raw.get("unitPrice"),
+        "currency_code": raw.get("currencyCode"),
+        "unit_of_measure": raw.get("unitOfMeasure"),
+        "meter_id": raw.get("meterId"),
+        "meter_name": raw.get("meterName"),
+        "product_name": raw.get("productName"),
+        "service_name": raw.get("serviceName"),
+        "service_family": raw.get("serviceFamily"),
+        "arm_sku_name": raw.get("armSkuName"),
+        "sku_name": raw.get("skuName"),
+        "arm_region_name": raw.get("armRegionName"),
+        "location": raw.get("location"),
+        "price_type": raw.get("type") or raw.get("priceType"),
+        "reservation_term": raw.get("reservationTerm"),
+        "effective_start_date": raw.get("effectiveStartDate"),
+    }
+
+
+def pricing_lookup_sku(
+    sku: str,
+    region: str,
+    term: Literal["ondemand", "1yr", "3yr"] = "ondemand",
+    currency: str = "USD",
+) -> dict[str, Any]:
+    """Look up retail pricing for a single Azure SKU in a region.
+
+    Calls the public Azure Retail Prices API. No authentication is used and no
+    Azure SDK call is made. Read-only by design (ADR-003).
+
+    Args:
+        sku: SKU name. Either ARM form ('Standard_D2s_v5') or friendly form
+            ('D2s v5'). The filter matches both.
+        region: ARM region name, lower-case ('westeurope', 'eastus2', etc.).
+        term: Pricing term. 'ondemand' for Consumption (PAYG). '1yr' or '3yr'
+            for Reservation pricing where Microsoft publishes it.
+        currency: ISO currency code. Defaults to 'USD'. Forwarded to the API
+            via the currencyCode query parameter.
+
+    Returns:
+        Dict with the original inputs plus an ``items`` list of pricing rows.
+        Each item exposes retail_price, unit_price, unit_of_measure, meter_id,
+        and other fields documented in the API reference. Empty ``items`` means
+        the SKU was not found for the region/term combination; this is not an
+        error.
+
+    Caveats:
+        - Retail prices only. EA, CSP, and private rate cards are not exposed.
+        - USD default. Pass ``currency`` for other ISO codes supported by the API.
+        - No real-time freshness SLA from Microsoft. Results are cached for 24h.
+        - Reservation rows appear only where Microsoft publishes them in the meter.
+
+    Reference:
+        https://learn.microsoft.com/rest/api/cost-management/retail-prices/azure-retail-prices
+    """
+    odata_filter = _build_filter(sku, region, term)
+    raw_items = _fetch_with_cache(odata_filter, currency)
+    items = [_shape_item(r) for r in raw_items]
+    source_url = f"{PRICING_ENDPOINT}?$filter={odata_filter}&currencyCode={currency}"
+    return {
+        "sku": sku,
+        "region": region,
+        "term": term,
+        "currency": currency,
+        "items": items,
+        "item_count": len(items),
+        "cached_at": int(time.time()),
+        "source_url": source_url,
+    }
+
+
+def _hourly_from_unit(unit_price: Any, unit_of_measure: str | None) -> float | None:
+    """Best-effort conversion of a metered unit price to an hourly rate.
+
+    Many compute SKUs are metered as '1 Hour'. Some are '100 Hours' or '10 Hours'.
+    Storage and most other meters are not hourly and return None. The caller
+    should display unit_of_measure alongside any derived hourly figure so the
+    user can sanity-check.
+    """
+    if unit_price is None or unit_of_measure is None:
+        return None
+    uom = unit_of_measure.strip().lower()
+    try:
+        price = float(unit_price)
+    except (TypeError, ValueError):
+        return None
+    if uom in ("1 hour", "hour"):
+        return price
+    if uom == "100 hours":
+        return price / 100.0
+    if uom == "10 hours":
+        return price / 10.0
+    if uom == "1000 hours":
+        return price / 1000.0
+    return None
+
+
+def pricing_compare_skus(
+    skus: list[str],
+    region: str,
+    term: str = "ondemand",
+    currency: str = "USD",
+) -> dict[str, Any]:
+    """Compare retail pricing for multiple SKUs side by side in one region.
+
+    Calls ``pricing_lookup_sku`` per SKU and assembles a comparison table.
+    Designed for sizing trade-off review and for the future design-review skill
+    to compare candidate options in a single response.
+
+    Args:
+        skus: SKU names to compare. Capped at 10 entries to bound the API
+            response size. Pass fewer than 10 for typical sizing review.
+        region: ARM region name, lower-case.
+        term: 'ondemand', '1yr', or '3yr'. See ``pricing_lookup_sku``.
+        currency: ISO currency code. Defaults to 'USD'.
+
+    Returns:
+        Dict with region, term, currency, and a ``comparison`` list. Each entry
+        carries the SKU, a representative item (cheapest unit_price seen for
+        that SKU/region/term), and a derived ``hourly`` and ``monthly_730h``
+        figure where the meter is hourly. Items whose meter is not hourly
+        report hourly/monthly as None and the caller should consult
+        unit_of_measure.
+
+    Raises:
+        ValueError: If ``skus`` is empty or exceeds the 10-SKU cap.
+    """
+    if not skus:
+        raise ValueError("skus must contain at least one entry.")
+    if len(skus) > _COMPARE_MAX_SKUS:
+        raise ValueError(
+            f"skus exceeds the {_COMPARE_MAX_SKUS}-entry cap (got {len(skus)}). "
+            f"Split the request to keep responses bounded."
+        )
+
+    comparison: list[dict[str, Any]] = []
+    for sku in skus:
+        result = pricing_lookup_sku(
+            sku=sku,
+            region=region,
+            term=term,  # type: ignore[arg-type]
+            currency=currency,
+        )
+        items = result["items"]
+        cheapest: dict[str, Any] | None = None
+        for item in items:
+            price = item.get("unit_price")
+            if price is None:
+                continue
+            if cheapest is None or float(price) < float(cheapest["unit_price"]):
+                cheapest = item
+
+        hourly = (
+            _hourly_from_unit(cheapest["unit_price"], cheapest.get("unit_of_measure"))
+            if cheapest is not None
+            else None
+        )
+        monthly = round(hourly * 730.0, 4) if hourly is not None else None
+
+        comparison.append(
+            {
+                "sku": sku,
+                "found": cheapest is not None,
+                "unit_price": cheapest["unit_price"] if cheapest else None,
+                "unit_of_measure": cheapest.get("unit_of_measure") if cheapest else None,
+                "currency_code": cheapest.get("currency_code") if cheapest else currency,
+                "meter_id": cheapest.get("meter_id") if cheapest else None,
+                "product_name": cheapest.get("product_name") if cheapest else None,
+                "hourly": hourly,
+                "monthly_730h": monthly,
+                "item_count": len(items),
+            }
+        )
+
+    return {
+        "region": region,
+        "term": term,
+        "currency": currency,
+        "comparison": comparison,
+        "notes": (
+            "monthly_730h uses the standard 730-hour month convention. "
+            "Items whose meter is not hourly report hourly/monthly as null; "
+            "consult unit_of_measure. Retail prices only (no EA/CSP)."
+        ),
+    }
+
+
+def _clear_cache_for_tests() -> None:
+    """Test helper. Not exported as an MCP tool."""
+    _CACHE.clear()

--- a/src/mcp_server_azure_architect/server.py
+++ b/src/mcp_server_azure_architect/server.py
@@ -1,9 +1,17 @@
 """FastMCP server instance and tool definitions."""
 
+from typing import Any, Literal
+
 from mcp.server.fastmcp import FastMCP
 
 from mcp_server_azure_architect import __version__
 from mcp_server_azure_architect.alz_queries import get_query
+from mcp_server_azure_architect.pricing import (
+    pricing_compare_skus as _pricing_compare_skus,
+)
+from mcp_server_azure_architect.pricing import (
+    pricing_lookup_sku as _pricing_lookup_sku,
+)
 
 mcp = FastMCP("azure-architect")
 
@@ -47,3 +55,37 @@ def alz_query_by_id(checklist_id: str) -> dict[str, str]:
     """
     record = get_query(checklist_id)
     return {key: str(value) for key, value in record.items()}
+
+
+@mcp.tool()
+def pricing_lookup_sku(
+    sku: str,
+    region: str,
+    term: Literal["ondemand", "1yr", "3yr"] = "ondemand",
+    currency: str = "USD",
+) -> dict[str, Any]:
+    """Look up Azure retail pricing for a single SKU in a region.
+
+    Calls the public Azure Retail Prices API. No auth, no Azure SDK, read-only.
+    Results cached for 24h. Caveats: retail only (no EA/CSP), USD default,
+    no real-time freshness SLA.
+    """
+    return _pricing_lookup_sku(sku=sku, region=region, term=term, currency=currency)
+
+
+@mcp.tool()
+def pricing_compare_skus(
+    skus: list[str],
+    region: str,
+    term: str = "ondemand",
+    currency: str = "USD",
+) -> dict[str, Any]:
+    """Compare retail pricing for multiple Azure SKUs side by side in one region.
+
+    Wraps pricing_lookup_sku per SKU. Capped at 10 SKUs per call. Useful for
+    sizing trade-off review. Raises ValueError if the cap is exceeded or skus
+    is empty.
+    """
+    return _pricing_compare_skus(
+        skus=skus, region=region, term=term, currency=currency
+    )

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,377 @@
+"""Tests for the native Azure retail pricing tools."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from mcp_server_azure_architect import pricing
+
+
+@pytest.fixture(autouse=True)
+def _clear_pricing_cache() -> None:
+    pricing._clear_cache_for_tests()
+
+
+def _make_item(
+    arm_sku: str = "Standard_D2s_v5",
+    region: str = "westeurope",
+    price: float = 0.096,
+    uom: str = "1 Hour",
+    price_type: str = "Consumption",
+    reservation_term: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "currencyCode": "USD",
+        "tierMinimumUnits": 0.0,
+        "retailPrice": price,
+        "unitPrice": price,
+        "armRegionName": region,
+        "location": "EU West",
+        "effectiveStartDate": "2024-01-01T00:00:00Z",
+        "meterId": "00000000-0000-0000-0000-000000000001",
+        "meterName": f"{arm_sku} meter",
+        "productId": "DZH318Z0BQPS",
+        "skuId": "0001",
+        "productName": "Virtual Machines DSv5 Series",
+        "skuName": arm_sku.replace("Standard_", "").replace("_", " "),
+        "serviceName": "Virtual Machines",
+        "serviceId": "DZH313Z7MMC8",
+        "serviceFamily": "Compute",
+        "unitOfMeasure": uom,
+        "type": price_type,
+        "isPrimaryMeterRegion": True,
+        "armSkuName": arm_sku,
+        "reservationTerm": reservation_term,
+    }
+
+
+def _install_mock_transport(
+    handler: Any,
+) -> Any:
+    """Patch pricing._get_client to return an httpx.Client backed by MockTransport."""
+    transport = httpx.MockTransport(handler)
+
+    def _factory() -> httpx.Client:
+        return httpx.Client(transport=transport)
+
+    return patch.object(pricing, "_get_client", _factory)
+
+
+def test_lookup_sku_happy_path() -> None:
+    """Mock the API, assert correct OData filter built and parsed response correct."""
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["filter"] = request.url.params.get("$filter")
+        captured["currency"] = request.url.params.get("currencyCode")
+        return httpx.Response(
+            200,
+            json={"Items": [_make_item()], "NextPageLink": None, "Count": 1},
+        )
+
+    with _install_mock_transport(handler):
+        result = pricing.pricing_lookup_sku(
+            sku="Standard_D2s_v5", region="westeurope", term="ondemand"
+        )
+
+    assert "armSkuName eq 'Standard_D2s_v5'" in captured["filter"]
+    assert "armRegionName eq 'westeurope'" in captured["filter"]
+    assert "priceType eq 'Consumption'" in captured["filter"]
+    assert "reservationTerm" not in captured["filter"]
+    assert captured["currency"] == "USD"
+
+    assert result["sku"] == "Standard_D2s_v5"
+    assert result["region"] == "westeurope"
+    assert result["term"] == "ondemand"
+    assert result["item_count"] == 1
+    assert result["items"][0]["retail_price"] == 0.096
+    assert result["items"][0]["unit_of_measure"] == "1 Hour"
+    assert result["items"][0]["arm_sku_name"] == "Standard_D2s_v5"
+
+
+def test_lookup_sku_reservation_term_in_filter() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["filter"] = request.url.params.get("$filter")
+        return httpx.Response(
+            200,
+            json={
+                "Items": [
+                    _make_item(
+                        price=0.05,
+                        uom="1 Hour",
+                        price_type="Reservation",
+                        reservation_term="1 Year",
+                    )
+                ],
+                "NextPageLink": None,
+            },
+        )
+
+    with _install_mock_transport(handler):
+        result = pricing.pricing_lookup_sku(
+            sku="Standard_D2s_v5", region="westeurope", term="1yr"
+        )
+
+    assert "priceType eq 'Reservation'" in captured["filter"]
+    assert "reservationTerm eq '1 Year'" in captured["filter"]
+    assert result["items"][0]["reservation_term"] == "1 Year"
+
+
+def test_lookup_sku_pagination() -> None:
+    """Mock returns NextPageLink once. Assert second call is made and results combined."""
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        calls.append(url)
+        if len(calls) == 1:
+            return httpx.Response(
+                200,
+                json={
+                    "Items": [_make_item(price=0.10)],
+                    "NextPageLink": "https://prices.azure.com/api/retail/prices?page=2",
+                },
+            )
+        return httpx.Response(
+            200,
+            json={"Items": [_make_item(price=0.20)], "NextPageLink": None},
+        )
+
+    with _install_mock_transport(handler):
+        result = pricing.pricing_lookup_sku(
+            sku="Standard_D2s_v5", region="westeurope"
+        )
+
+    assert len(calls) == 2
+    assert "page=2" in calls[1]
+    assert result["item_count"] == 2
+    prices = sorted(item["retail_price"] for item in result["items"])
+    assert prices == [0.10, 0.20]
+
+
+def test_lookup_sku_pagination_capped() -> None:
+    """If the API keeps returning NextPageLink, abort at the defensive cap."""
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(
+            200,
+            json={
+                "Items": [_make_item(price=0.01 * call_count)],
+                "NextPageLink": (
+                    f"https://prices.azure.com/api/retail/prices?page={call_count + 1}"
+                ),
+            },
+        )
+
+    with _install_mock_transport(handler):
+        result = pricing.pricing_lookup_sku(
+            sku="Standard_D2s_v5", region="westeurope"
+        )
+
+    assert call_count == pricing._MAX_PAGES
+    assert result["item_count"] == pricing._MAX_PAGES
+
+
+def test_lookup_sku_caching() -> None:
+    """Call twice with the same args. Assert the second call is served from cache."""
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(
+            200, json={"Items": [_make_item()], "NextPageLink": None}
+        )
+
+    with _install_mock_transport(handler):
+        pricing.pricing_lookup_sku(sku="Standard_D2s_v5", region="westeurope")
+        pricing.pricing_lookup_sku(sku="Standard_D2s_v5", region="westeurope")
+
+    assert call_count == 1
+
+
+def test_lookup_sku_cache_currency_isolation() -> None:
+    """Different currency should not collide on the cache key."""
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(
+            200, json={"Items": [_make_item()], "NextPageLink": None}
+        )
+
+    with _install_mock_transport(handler):
+        pricing.pricing_lookup_sku(
+            sku="Standard_D2s_v5", region="westeurope", currency="USD"
+        )
+        pricing.pricing_lookup_sku(
+            sku="Standard_D2s_v5", region="westeurope", currency="EUR"
+        )
+
+    assert call_count == 2
+
+
+def test_lookup_sku_empty_results() -> None:
+    """Empty Items should produce an empty items list, not an error."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"Items": [], "NextPageLink": None})
+
+    with _install_mock_transport(handler):
+        result = pricing.pricing_lookup_sku(
+            sku="Standard_NotARealSku", region="westeurope"
+        )
+
+    assert result["items"] == []
+    assert result["item_count"] == 0
+
+
+def test_lookup_sku_invalid_term_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown term"):
+        pricing.pricing_lookup_sku(
+            sku="Standard_D2s_v5", region="westeurope", term="lifetime"  # type: ignore[arg-type]
+        )
+
+
+def test_odata_escape_handles_single_quote() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["filter"] = request.url.params.get("$filter")
+        return httpx.Response(200, json={"Items": [], "NextPageLink": None})
+
+    with _install_mock_transport(handler):
+        pricing.pricing_lookup_sku(sku="Foo'Bar", region="westeurope")
+
+    assert "Foo''Bar" in captured["filter"]
+
+
+def test_compare_skus_combines_results() -> None:
+    """compare_skus should call lookup per SKU and assemble a comparison table."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        sku_clause = request.url.params.get("$filter") or ""
+        if "D2s_v5" in sku_clause:
+            return httpx.Response(
+                200,
+                json={"Items": [_make_item("Standard_D2s_v5", price=0.096)],
+                      "NextPageLink": None},
+            )
+        if "D4s_v5" in sku_clause:
+            return httpx.Response(
+                200,
+                json={"Items": [_make_item("Standard_D4s_v5", price=0.192)],
+                      "NextPageLink": None},
+            )
+        return httpx.Response(200, json={"Items": [], "NextPageLink": None})
+
+    with _install_mock_transport(handler):
+        result = pricing.pricing_compare_skus(
+            skus=["Standard_D2s_v5", "Standard_D4s_v5"], region="westeurope"
+        )
+
+    assert result["region"] == "westeurope"
+    assert len(result["comparison"]) == 2
+    rows = {row["sku"]: row for row in result["comparison"]}
+    assert rows["Standard_D2s_v5"]["found"] is True
+    assert rows["Standard_D2s_v5"]["hourly"] == pytest.approx(0.096)
+    assert rows["Standard_D2s_v5"]["monthly_730h"] == pytest.approx(0.096 * 730, rel=1e-3)
+    assert rows["Standard_D4s_v5"]["hourly"] == pytest.approx(0.192)
+
+
+def test_compare_skus_marks_missing_sku() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"Items": [], "NextPageLink": None})
+
+    with _install_mock_transport(handler):
+        result = pricing.pricing_compare_skus(
+            skus=["Standard_NotReal"], region="westeurope"
+        )
+
+    row = result["comparison"][0]
+    assert row["found"] is False
+    assert row["unit_price"] is None
+    assert row["hourly"] is None
+    assert row["monthly_730h"] is None
+
+
+def test_compare_skus_size_cap() -> None:
+    too_many = [f"Standard_X{i}" for i in range(11)]
+    with pytest.raises(ValueError, match="cap"):
+        pricing.pricing_compare_skus(skus=too_many, region="westeurope")
+
+
+def test_compare_skus_empty_raises() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        pricing.pricing_compare_skus(skus=[], region="westeurope")
+
+
+def test_no_httpx_at_pricing_module_top() -> None:
+    """The pricing module by itself must not pull httpx into sys.modules.
+
+    Cold-start guard: httpx is only allowed to load when a tool is actually
+    invoked from the pricing module, not when the module is imported. The
+    server module separately depends on FastMCP, which transitively loads
+    httpx; that is outside this module's control. Run in a subprocess so we
+    do not perturb sys.modules in the current test session.
+    """
+    import subprocess
+
+    code = (
+        "import sys\n"
+        "import mcp_server_azure_architect.pricing  # noqa: F401\n"
+        "assert 'httpx' not in sys.modules, "
+        "'httpx must not load at pricing module import time'\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_server_registers_pricing_tools() -> None:
+    """The MCP server should expose both pricing tools with valid metadata."""
+    from mcp_server_azure_architect.server import mcp as server_mcp
+
+    tools = server_mcp._tool_manager.list_tools()
+    names = {tool.name for tool in tools}
+
+    assert "pricing_lookup_sku" in names
+    assert "pricing_compare_skus" in names
+
+    lookup_tool = next(t for t in tools if t.name == "pricing_lookup_sku")
+    assert lookup_tool.description is not None
+    assert "retail" in lookup_tool.description.lower()
+
+
+def test_pricing_lookup_sku_via_server_tool() -> None:
+    """Exercise the MCP-registered pricing_lookup_sku end to end."""
+    from mcp_server_azure_architect.server import pricing_lookup_sku as server_tool
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"Items": [_make_item()], "NextPageLink": None}
+        )
+
+    with _install_mock_transport(handler):
+        result = server_tool(sku="Standard_D2s_v5", region="westeurope")
+
+    assert result["item_count"] == 1
+    assert result["items"][0]["arm_sku_name"] == "Standard_D2s_v5"


### PR DESCRIPTION
## Summary

Native Azure retail pricing tools, ships `pricing_lookup_sku` and `pricing_compare_skus`. Public HTTP GET against the Azure Retail Prices API. No auth, no Azure SDK on this path. `pricing_estimate_workload` deferred to follow-up #44 because it needs a `WorkloadSpec` model that is not yet defined.

Closes #39 (partial: lookup + compare).
Follow-up: #44 for `pricing_estimate_workload`.

## Design

- **Module:** `src/mcp_server_azure_architect/pricing.py`. Top-of-file comment marks it READ-ONLY per ADR-003.
- **Lazy `httpx` import:** `def _get_client(): import httpx; ...`. The pricing module itself does not pull httpx into `sys.modules` at import time. `test_no_httpx_at_pricing_module_top` enforces this in a subprocess. Note: FastMCP already loads httpx transitively, so the new direct dep adds zero net cold-start cost.
- **24h in-memory TTL cache:** Module-level `dict[str, tuple[float, list[dict]]]`. Key includes currency to avoid cross-currency collision. No new dep.
- **OData escaping:** Single quotes are doubled per OData spec. Unit-tested with `Foo'Bar` SKU input.
- **Pagination:** Follows `NextPageLink` with a defensive cap of 5 pages (5000 rows worst-case). Cap is documented; runaway-protection only.
- **Compare cap:** `pricing_compare_skus` rejects > 10 SKUs to bound response size. Empty list also rejected.

## Validation gates

- `ruff check .` clean
- `mypy src/mcp_server_azure_architect tests` clean
- `pytest -q` 20 passed (4 prior + 16 new)
- `test_server_cold_start_under_threshold` passes both soft (1000ms) and hard (2000ms) gates
- Cold-start (warm-import methodology, matches baseline measurement): median 4.4ms, p90 7.5ms. Well under the 50ms delta budget from #39.

## ADR + threat-model alignment

- **ADR-003 (read-only):** Module performs HTTP GET only. No Azure SDK, no `begin_*`/`create_*`/`update_*`/`delete_*` methods anywhere in the call graph. Layer-1 AST allowlist (issue #7) will recognize the import set as safe.
- **ADR-004 (companion bar):** This issue is the canonical native-vs-companion case study cited by Burke. No standalone Azure pricing MCP exists; `azure-mcp` does not cover retail pricing.
- **Threat model (Sentinel):** Public HTTP dep is a low-risk class. No auth surface, no PII, no caller-provided `subscription_id` (so no confused-deputy). Supply-chain risk for `httpx` is bounded by the `>=0.27.0,<1.0.0` pin in `pyproject.toml`.

## Out of scope

- `pricing_estimate_workload`: deferred to #44 (needs `WorkloadSpec` model).
- README / skill catalog updates: tracked separately so this PR stays focused on the runtime tools.
- Threat-model addendum: low-risk class already covered by Sentinel's STRIDE-Lite supply-chain section; can be appended in a follow-up if Sentinel wants explicit naming.