### PR TITLE
test(ci): add MCP Inspector smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,24 @@ jobs:
       
       - name: Run pytest
         run: pytest -v
+
+  inspector-smoke:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      
+      - name: Install uv
+        run: pip install uv
+      
+      - name: Install dependencies
+        run: uv pip install --system -e ".[dev]"
+      
+      - name: Run MCP smoke test
+        run: python scripts/mcp_smoke.py

--- a/.squad/agents/forge/history.md
+++ b/.squad/agents/forge/history.md
@@ -264,3 +264,21 @@ Shipped the alz_scorecard MCP tool: runs vendored ALZ queries against Azure Reso
 - **Alphabetical slicing for deterministic truncation.** When full sweep or pillar filter exceeds 25-query cap, slice to first 25 alphabetical and set truncated: true. Alphabetical order is neutral and reproducible.
 - **asyncio.to_thread for sync SDK in async context.** ResourceGraphClient.resources() is synchronous. Wrap in asyncio.to_thread(_blocking_call) to enable concurrent gather without blocking the event loop. This pattern enables async tool signatures in FastMCP while composing with sync Azure SDK clients.
 - **Composition > duplication.** Scorecard reuses get_query() and list_query_ids() from alz_queries.py (PR #45). No duplication. Single source of truth for query text and metadata.
+
+## 2026-05-12T15:00:00Z - PR #TBD: MCP Inspector smoke test in CI (closes #19)
+
+Shipped `scripts/mcp_smoke.py` and `inspector-smoke` CI job to catch tool registration regressions, JSON Schema validity failures, and basic protocol breakage.
+
+**PR:** #TBD test(ci): add MCP Inspector smoke test  
+**Closes:** #19  
+**Validation:** smoke test exits 0 locally, ruff clean, mypy clean (extended to scripts/), pytest 41/41.
+
+### Learnings
+
+- **Python mcp.client.stdio > npm Inspector for CI.** The `mcp` SDK's stdio_client lets us spawn the server and validate the protocol without npm install overhead. Smoke test runtime < 5s, total CI job time < 60s. This is the same path Copilot CLI skills will use, so we validate the real client integration.
+- **Separate CI job for smoke tests.** Protocol-level smoke tests belong in their own job, not mixed with unit tests. Different failure modes (subprocess server spawn vs mocked FastMCP), cleaner signal when something breaks.
+- **Hardcoded tool list is acceptable at this scale.** `EXPECTED_TOOLS` frozenset in the smoke script must be updated when tools are added/removed. At 5 tools, manual update is fine. If we hit 10+, consider introspecting `server.py` exports at test time.
+- **async with context manager combining.** Python 3.10+ `async with (ctx1, ctx2):` syntax (ruff SIM117) is cleaner than nested `async with` blocks. Applied to stdio_client + ClientSession pairing.
+- **MCP tool results are JSON-serialized strings.** FastMCP returns dicts from tool functions, but the MCP protocol layer serializes them to JSON text in `result.content[0].text`. Smoke test must `json.loads()` to validate structure.
+- **Exit code + stderr is the CI contract.** Smoke script exits 0 on success, non-zero with human-readable diagnostics to stderr on failure. No logging or external deps needed, CI parses exit code.
+

--- a/.squad/decisions/inbox/forge-mcp-inspector-ci.md
+++ b/.squad/decisions/inbox/forge-mcp-inspector-ci.md
@@ -1,0 +1,90 @@
+# Decision: MCP Inspector Smoke Test in CI
+
+**Status:** Implemented  
+**Decider:** Forge  
+**Date:** 2026-05-12  
+**Issue:** #19
+
+## Context
+
+The server now has 5 tools registered. We need automated validation in CI to catch:
+1. Tool registration regressions (missing or extra tools)
+2. JSON Schema validity failures for tool inputs
+3. Basic protocol layer breakage
+
+The MCP Inspector exists as `@modelcontextprotocol/inspector` (npm), but installing npm in the Python CI adds complexity and latency. The `mcp` Python SDK already provides `stdio_client` for talking to MCP servers, which is what the Inspector uses under the hood.
+
+## Decision
+
+Ship a Python smoke test script (`scripts/mcp_smoke.py`) that uses the `mcp.client.stdio` SDK to:
+1. Spawn the server via stdio transport
+2. Send `tools/list` request
+3. Assert exactly 5 expected tools are registered
+4. Validate every tool's inputSchema has `type: "object"` and a `properties` dict
+5. Call `health_check` and assert response shape (`status: "ok"`, non-empty `version`)
+
+Add a separate CI job `inspector-smoke` (ubuntu-latest, Python 3.12 only) that runs the script. No need to matrix across Python versions, one smoke run per PR is sufficient.
+
+## Rationale
+
+**Why Python SDK over npm Inspector:**
+- Zero npm install overhead (CI time budget)
+- Reuses existing `mcp[cli]` dependency from `[dev]` extras
+- Validates the Python client path (the one Copilot CLI skills will use)
+
+**Why separate job from `test`:**
+- Isolation. Smoke test spawns a subprocess server, different failure mode than unit tests.
+- Clear signal in CI status. If `inspector-smoke` fails, it's a protocol/registration issue, not a unit test.
+
+**Why Python 3.12 only:**
+- Smoke test is protocol-level, not Python-version-sensitive.
+- Running on both 3.11 and 3.12 doubles cost for no signal gain.
+
+**What the smoke asserts:**
+1. Tool registration completeness: exactly `health_check`, `alz_query_by_id`, `pricing_lookup_sku`, `pricing_compare_skus`, `alz_scorecard`
+2. JSON Schema validity: every tool has `inputSchema.type == "object"` and `inputSchema.properties` is a dict
+3. Basic invocability: `health_check` returns `{"status": "ok", "version": "0.0.1"}`
+
+**Read-only constraint:**
+Only `health_check` is invoked. No Azure calls. Smoke test runs offline.
+
+## Consequences
+
+**Positive:**
+- Catches tool registration regressions before merge (e.g., decorator typo, import error)
+- Validates JSON Schema generation from FastMCP type hints
+- Fast (< 5s runtime, under 60s total job time with install)
+
+**Negative:**
+- Hardcoded tool list. Adding a new tool requires updating `EXPECTED_TOOLS` in `scripts/mcp_smoke.py`.
+- Fragile to MCP protocol breaking changes in `mcp` SDK major version bumps (mitigated by upper-bound constraint in `pyproject.toml`).
+
+**Follow-up:**
+- Sentinel to add `inspector-smoke` to required-status-checks list in branch protection (not done in this PR per constraints).
+- If the tool count grows beyond 10, consider generating `EXPECTED_TOOLS` from `server.py` introspection (deferred, not needed yet).
+
+## Alternatives Considered
+
+**Alt 1: Use npm MCP Inspector in CI**  
+Rejected. Adds 15-30s npm install overhead, requires Node.js setup in CI, less control over assertions.
+
+**Alt 2: Inline smoke test in pytest suite**  
+Rejected. Spawning the server in a subprocess is slower than mocked unit tests, would dominate pytest runtime. Separate job is cleaner.
+
+**Alt 3: No smoke test, rely on unit tests**  
+Rejected. Unit tests mock FastMCP tool manager, don't validate end-to-end stdio transport or tool registration from the `__main__.py` entry point.
+
+## Implementation Notes
+
+- Script uses `async with` combining stdio_client and ClientSession (per ruff SIM117 lint rule).
+- JSON import is inline (after session setup) to defer import cost, though negligible here.
+- Exit code 0 on success, non-zero with stderr diagnostics on failure (CI-friendly pattern).
+- Script header documents what it asserts, for future maintainers who see a CI failure.
+
+## References
+
+- MCP SDK stdio client: https://github.com/modelcontextprotocol/python-sdk
+- FastMCP tool registration: https://github.com/jlowin/fastmcp
+- Issue #19: https://github.com/martinopedal/mcp-server-azure-architect/issues/19
+- CI job added: `.github/workflows/ci.yml` inspector-smoke
+- README updated: Development section now lists `python scripts/mcp_smoke.py` for local validation

--- a/README.md
+++ b/README.md
@@ -108,6 +108,36 @@ All tools are read-only by design. No Azure write operations are exposed.
 
 For more details on the runtime choice, see [docs/adr/0001-runtime-choice.md](docs/adr/0001-runtime-choice.md).
 
+## Development
+
+### Run Smoke Tests
+
+Before pushing changes or as part of local validation, run the MCP smoke test to verify tool registration, JSON Schema validity, and basic invocability:
+
+```bash
+python scripts/mcp_smoke.py
+```
+
+This test validates that:
+- All expected tools are registered (health_check, alz_query_by_id, pricing_lookup_sku, pricing_compare_skus, alz_scorecard)
+- Every tool has a valid JSON Schema for its inputs
+- The health_check tool can be invoked successfully
+
+The smoke test does NOT call Azure, it only exercises the MCP protocol layer.
+
+### Run Tests
+
+```bash
+pytest -v
+```
+
+### Linting and Type Checking
+
+```bash
+ruff check .
+mypy src
+```
+
 ## License
 
 MIT.

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""MCP Inspector smoke test for mcp-server-azure-architect.
+
+Validates the running MCP server against three invariants:
+
+1. **Tool registration completeness:** Exactly the expected 5 tools are
+   registered (health_check, alz_query_by_id, pricing_lookup_sku,
+   pricing_compare_skus, alz_scorecard). Catches tool addition/removal
+   regressions.
+
+2. **JSON Schema validity:** Every tool's inputSchema has type "object"
+   and a "properties" dict. This is the minimal contract for MCP clients
+   to generate forms or validate calls.
+
+3. **Basic invocability:** Calling health_check returns a dict with
+   status "ok" and a non-empty version string. Validates the end-to-end
+   stdio transport + tool dispatch path without calling Azure.
+
+Intended for CI (inspector-smoke job) and local pre-commit validation.
+Exit 0 on all assertions passing, non-zero with human-readable error on
+any failure.
+
+Usage:
+    python scripts/mcp_smoke.py
+
+Dependencies:
+    mcp[cli]>=1.27.0 (from project [dev] extras)
+
+Note: This script does NOT call Azure. Only health_check is invoked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+EXPECTED_TOOLS = frozenset(
+    [
+        "health_check",
+        "alz_query_by_id",
+        "pricing_lookup_sku",
+        "pricing_compare_skus",
+        "alz_scorecard",
+    ]
+)
+
+
+async def run_smoke_test() -> None:
+    """Run the MCP smoke test suite."""
+    # Spawn the server via stdio transport
+    server_params = StdioServerParameters(
+        command="python",
+        args=["-m", "mcp_server_azure_architect"],
+        env=None,
+    )
+
+    async with (
+        stdio_client(server_params) as (read, write),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+
+        # 1. List tools
+        tools_result = await session.list_tools()
+        tools = tools_result.tools
+
+        tool_names = {tool.name for tool in tools}
+
+        # 2. Assert exactly expected tool set
+        if tool_names != EXPECTED_TOOLS:
+            missing = EXPECTED_TOOLS - tool_names
+            extra = tool_names - EXPECTED_TOOLS
+            error_lines = ["Tool registration mismatch:"]
+            if missing:
+                error_lines.append(f"  Missing: {sorted(missing)}")
+            if extra:
+                error_lines.append(f"  Extra: {sorted(extra)}")
+            error_lines.append(f"  Expected: {sorted(EXPECTED_TOOLS)}")
+            error_lines.append(f"  Got: {sorted(tool_names)}")
+            print("\n".join(error_lines), file=sys.stderr)
+            sys.exit(1)
+
+        print(f"✓ Tool registration: {len(tools)} tools match expected set")
+
+        # 3. Validate JSON Schema for each tool
+        for tool in tools:
+            input_schema = tool.inputSchema
+            if not isinstance(input_schema, dict):
+                print(
+                    f"✗ Tool {tool.name}: inputSchema is not a dict",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            if input_schema.get("type") != "object":
+                print(
+                    f"✗ Tool {tool.name}: inputSchema.type is not 'object'",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            if "properties" not in input_schema:
+                print(
+                    f"✗ Tool {tool.name}: inputSchema missing 'properties'",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            if not isinstance(input_schema["properties"], dict):
+                print(
+                    f"✗ Tool {tool.name}: inputSchema.properties is not a dict",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+        print("✓ JSON Schema validity: all tools have valid inputSchema")
+
+        # 4. Call health_check and validate response shape
+        result = await session.call_tool("health_check", arguments={})
+
+        if not result.content:
+            print(
+                "✗ health_check returned no content",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        # Extract the text content from the result
+        content_item = result.content[0]
+        if not hasattr(content_item, "text"):
+            print(
+                "✗ health_check content[0] has no text attribute",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        # The MCP protocol returns tool results as JSON-serialized strings
+        import json
+
+        try:
+            response_data = json.loads(content_item.text)
+        except json.JSONDecodeError as e:
+            print(
+                f"✗ health_check response is not valid JSON: {e}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        if not isinstance(response_data, dict):
+            print(
+                f"✗ health_check response is not a dict: {type(response_data)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        status = response_data.get("status")
+        version = response_data.get("version")
+
+        if status != "ok":
+            print(
+                f"✗ health_check status is not 'ok': {status}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        if not version or not isinstance(version, str):
+            print(
+                f"✗ health_check version is empty or not a string: {version}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        print(f"✓ Basic invocability: health_check returned status=ok, version={version}")
+
+    print("\n✓ All smoke tests passed")
+
+
+def main() -> None:
+    """Entry point."""
+    try:
+        asyncio.run(run_smoke_test())
+    except Exception as e:
+        print(f"\n✗ Smoke test failed with exception: {e}", file=sys.stderr)
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #19

## Summary

Ships scripts/mcp_smoke.py and inspector-smoke CI job to catch tool registration regressions, JSON Schema validity failures, and basic protocol breakage.

## What the smoke asserts

1. **Tool registration completeness:** Exactly 5 tools are registered (health_check, alz_query_by_id, pricing_lookup_sku, pricing_compare_skus, alz_scorecard)
2. **JSON Schema validity:** Every tool's inputSchema has type 'object' and a properties dict
3. **Basic invocability:** health_check returns status=ok and a non-empty version string

## Implementation

- Uses mcp.client.stdio SDK directly (not npm Inspector) to validate the Python client path and avoid npm install overhead
- Separate CI job inspector-smoke (ubuntu-latest, Python 3.12 only) isolates protocol-level smoke from unit tests
- Runtime < 5s, total job time < 60s
- Read-only: only health_check is invoked, no Azure calls

## Validation gates passed

- [x] python scripts/mcp_smoke.py exits 0 locally
- [x] python -m pytest -q — all 41 tests green
- [x] python -m ruff check . — clean
- [x] python -m mypy src tests scripts — clean

## Next steps for Sentinel

Once this PR merges, Sentinel should add inspector-smoke to the required-status-checks list in branch protection settings (not done in this PR per squad constraints).