### PR TITLE
feat(kit): cross-platform installer for companion kit

### DIFF
--- a/.squad/agents/burke/history.md
+++ b/.squad/agents/burke/history.md
@@ -58,3 +58,14 @@ MCP server public surface = tool names, parameter names/types, return shapes, do
 ## Team Update (2026-05-15)
 
 Wave 5 release pipeline shipped. v0.1.0 ready for tag cut once PR merges and Lead approves. Pipeline tested with local build smoke test. One-time PyPI trusted publishing setup documented for first release. PR #16 (kit installer) in separate worktree, low conflict risk (different pyproject.toml sections).
+## Session 3: Kit installer script (Issue #16, PR #16, 2026-05-12)
+
+Delivered cross-platform kit installer (`scripts/install_kit.py`) that automates the onboarding flow for architects: prerequisite checks, client detection (Copilot CLI, Claude Desktop, Cursor, VS Code), config merge with collision handling, and auth smoke tests. Key decisions: Python (stdlib only) for cross-platform portability, MERGE strategy that preserves existing servers with interactive prompts on collision, and run-from-repo distribution (no console_script entry yet). Supports `--dry-run` for preview and `--non-interactive` for CI. Comprehensive test coverage (23 tests, all green). Updated README to show installer as canonical quickstart path. Decision artifact in `.squad/decisions/inbox/burke-kit-installer.md`.
+
+### Learnings
+
+**Installer merge strategy must preserve existing work.** Architects may already have custom MCP servers configured. Overwriting their config files would delete existing work and break workflows. Solution: MERGE new servers into existing config, prompt on name collision (interactive), or skip (non-interactive). Backup invalid JSON configs before starting fresh. This pattern applies to any tool that modifies user-managed config files.
+
+**Stdlib-only Python scripts age better than scripted installers with dependencies.** Using only Python stdlib (no pip installs needed) means the installer runs anywhere Python 3.11+ is installed, with zero setup. No version conflicts, no `pip install installer-deps` step. For v0.1 tools where we're still learning user needs, stdlib-only reduces friction and maintenance burden.
+
+**Dry-run mode is essential for config-modifying tools.** Architects want to preview changes before committing, especially when merging into existing configs. `--dry-run` flag (prints merged JSON to stdout, touches no files) provides confidence and aids debugging. Standard pattern for infra tools (Terraform plan, Ansible check mode).

--- a/README.md
+++ b/README.md
@@ -2,160 +2,110 @@
 
 > **Not an official Microsoft product.** This is a personal community tool that **complements** the official Microsoft [`azure-mcp`](https://github.com/microsoft/azure-mcp) server, it does not replace it.
 
-MCP server and Copilot CLI skills bundle for Azure architects. Native tools fill the architect-shaped gap above `azure-mcp`: named ALZ checklist queries by ID, ALZ readiness scorecard, pricing lookup and comparison. Curated companion kit (Microsoft Learn, mermaid, Terraform, Kubernetes, etc.) bundles with one install.
+MCP server and Copilot CLI skills bundle for Azure architects. Native tools fill the architect-shaped gap above `azure-mcp`. A curated `mcp-config.json` ships alongside so an architect's "kit" (Microsoft Learn, mermaid, drawio, kubernetes, terraform companions) is one install.
 
 ## Why this exists
 
-`azure-mcp` already exposes Azure Resource Graph, Advisor, Monitor, Policy, RBAC, AKS, and more as MCP tools. Use it directly for those.
+`azure-mcp` already exposes Azure Resource Graph, Quota, Advisor, Monitor, Policy, RBAC, AKS, App Service, and more as MCP tools. Use it directly for those.
 
 What architects still need that `azure-mcp` does **not** ship:
 
-- **Named ALZ checklist queries.** Look up by checklist ID (not raw KQL), get the query, source attribution, and pillar classification.
-- **ALZ readiness scorecard.** Run vendored ALZ queries against a subscription, get pass/fail/unknown per item plus aggregate by pillar.
-- **Azure pricing tools.** Look up retail pricing by SKU and region, compare SKU costs side by side.
-- **Architect orchestration skills.** A `design-review` skill that pulls current state via `azure-mcp`, gaps via this server, and renders diagrams via `mermaid-mcp`. Similar skills for migration planning and policy review.
+- **Named ALZ checklist queries** (by checklist ID), not raw KQL.
+- **ALZ readiness scorecard** that composes many queries into one ranked, scored answer.
+- **Architect skills** that orchestrate the kit: a `design-review` skill that pulls current state via `azure-mcp`, gaps via this server, and renders a diagram via `mermaid-mcp`.
 
-This server is **not a router or aggregator.** MCP clients already aggregate. We ship the missing tools and a curated companion config.
+This server is **not a router or aggregator**. MCP clients already aggregate. We ship the missing tools and a curated companion config.
 
-## Native tools (5)
+## What's in scope
 
-| Tool | Purpose |
-|------|---------|
-| `health_check` | Check server health and version. One-line status response. |
-| `alz_query_by_id` | Vendored ALZ checklist query lookup by ID. Returns KQL text, source commit, and citation. Read-only snapshot scan, no Azure calls. |
-| `pricing_lookup_sku` | Azure retail pricing for one SKU in one region, one term. Calls public Retail Prices API (no auth). 24-hour cache. |
-| `pricing_compare_skus` | Compare retail pricing for multiple SKUs side by side. Useful for sizing trade-off review. Capped at 10 SKUs per call. |
-| `alz_scorecard` | Run vendored ALZ queries against a subscription via Azure Resource Graph. Returns per-item pass/fail/unknown plus aggregate by pillar. Capped at 25 queries per call. |
+- A small MCP server exposing two native tool families: `alz_query_by_id` (catalog lookup) and `alz_scorecard` (composition + scoring).
+- Copilot CLI skills: `design-review`, `alz-gap-check`, `ingress-migration-plan`, `policy-as-code-suggest`.
+- A curated `mcp-config.json` for Copilot CLI, Claude Desktop, Cursor, and VS Code Copilot.
+- Read-only by default, end to end.
 
-All tools are read-only. See [ADR-003](docs/adr/0003-read-only-enforcement.md) for enforcement details.
+## What's out of scope
 
-## Skills (8)
-
-Orchestration skills layer above the server and companion kit:
-
-| Skill | Purpose |
-|-------|---------|
-| `design-review` | Comprehensive Well-Architected review. Pulls current state, runs scorecard, highlights gaps, renders diagram. |
-| `alz-gap-check` | ALZ readiness mini-audit. Maps checklist items to resources found. Reports high-impact gaps. |
-| `ingress-migration-plan` | Kubernetes ingress migration planner. Current state via kubernetes-mcp, plan via orchestration. |
-| `policy-as-code-suggest` | Draft Azure Policy rules from unmet checklist items. Compliance-as-code pattern. |
-| `alz-vendoring` | Refresh ALZ query snapshot from upstream. Vendor management skill (internal). |
-| `fastmcp-bootstrap` | FastMCP new-tool scaffolding. Training skill. |
-| `mcp-runtime-evaluation` | Evaluate runtime choices for new tools. Training skill. |
-| `stride-lite-mcp-readonly` | Threat model for read-only tools. Training skill. |
-
-Each skill links to a `.squad/skills/*/SKILL.md` reference. See [docs/skills](docs/skills) for user-facing catalogs.
-
-## What's in scope and out of scope
-
-**In scope:**
-- Native MCP tools for ALZ checklist queries, scoring, and pricing lookup.
-- Read-only architect orchestration skills (design review, gap analysis, migration planning, policy drafting).
-- Curated companion kit via `mcp-config.json`.
-- DefaultAzureCredential auth, no mutation tools.
-
-**Out of scope:**
-- Wrapping or proxying `azure-mcp`. Anything `azure-mcp` already exposes (raw KQL, Advisor, Monitor, Policy, RBAC, AKS, App Service) is **explicitly out**.
+- Wrapping or proxying `azure-mcp`. Anything `azure-mcp` already exposes (raw KQL/ARG, quota, advisor, monitor, policy, RBAC, AKS, App Service) is **explicitly out**.
 - Mutation tools (create/update/delete on Azure). Read-only stays read-only.
-- Hosted multi-tenant deployment. Local-first only.
+- Hosted multi-tenant deployment. Local-first.
 
-## Architecture
+## Companion servers (recommended, not bundled)
 
-```mermaid
-graph TB
-    Client["MCP Client<br/>(Copilot CLI / Claude Desktop / Cursor / VS Code)"]
-    
-    subgraph This["mcp-server-azure-architect (5 tools)"]
-        HC["health_check"]
-        ALZ_QUERY["alz_query_by_id"]
-        PRICE_LOOKUP["pricing_lookup_sku"]
-        PRICE_COMPARE["pricing_compare_skus"]
-        SCORECARD["alz_scorecard"]
-    end
-    
-    subgraph Data["Data Sources"]
-        SNAPSHOT["vendored ALZ snapshot<br/>(data/alz-queries/)"]
-        AZURE["Azure subscription<br/>(via ARG)"]
-        RETAIL_API["prices.azure.com<br/>Retail Prices API"]
-    end
-    
-    subgraph Companions["Companion MCP Servers (peers, not children)"]
-        AZURE_MCP["azure-mcp"]
-        LEARN["microsoft-learn"]
-        GITHUB_MCP["github"]
-        MERMAID["mermaid"]
-        DRAWIO["drawio"]
-        K8S["kubernetes"]
-        TF["terraform"]
-    end
-    
-    subgraph Skills["Orchestration Skills<br/>(design-review, alz-gap-check, etc.)"]
-        SKILL_TEXT["8 architect skills<br/>composed from server + companions"]
-    end
-    
-    Client -->|MCP protocol| This
-    Client -->|MCP protocol| Companions
-    
-    ALZ_QUERY --> SNAPSHOT
-    SCORECARD --> SNAPSHOT
-    SCORECARD --> AZURE
-    PRICE_LOOKUP --> RETAIL_API
-    PRICE_COMPARE --> RETAIL_API
-    
-    Skills -->|call all above| This
-    Skills -->|call all above| Companions
-    
-    style This fill:#e1f5ff
-    style Companions fill:#f3e5f5
-    style Skills fill:#fffde7
-    style Data fill:#f1f8e9
-```
+| Server | Why an architect wants it |
+|--------|---------------------------|
+| `azure-mcp` (Microsoft) | ARG, Advisor, Monitor, Policy, RBAC, AKS, AppService, ... |
+| `microsoft-learn-mcp` | Grounded MS docs lookup |
+| `github` MCP | Repo, issue, PR access for IaC reviews |
+| `mermaid-mcp` | Render architecture diagrams inline |
+| `drawio-mcp` | Visio-replacement diagrams, exportable |
+| `kubernetes-mcp` | Live cluster inspection during design reviews |
+| `terraform-mcp` (HashiCorp) | Plan, validate, registry lookup |
+
+The default `mcp-config.json` shipped with this repo wires these up. Edit before use.
 
 ## Status
 
-Pre-alpha. Backlog tracked as GitHub issues with the `squad` label. Runtime, vendoring policy, read-only enforcement, and companion selection ratified via ADRs. See [docs/adr](docs/adr) for decisions.
+Pre-alpha. Backlog tracked as GitHub issues with the `squad` label. Runtime ratified per ADR-001 (Python + FastMCP).
 
 ## Stack
 
-Python 3.11+ with FastMCP, per [ADR-001](docs/adr/0001-runtime-choice.md). Build via Hatchling, lint with ruff, types with mypy, tests with pytest. Distribution via `uvx mcp-server-azure-architect` (end users); dev install via `uv pip install -e .`.
+Python 3.11+ with FastMCP, per [ADR-001](docs/adr/0001-runtime-choice.md). Build via Hatchling, lint with ruff, types with mypy, tests with pytest. Distribution via `uvx mcp-server-azure-architect`.
 
-**Note:** Package publication is forthcoming. When v0.1.0 publishes to PyPI, `uvx mcp-server-azure-architect` will be the canonical path. For now, use dev install or the install script (see Quickstart).
+Constraints:
 
-**Constraints:**
-- Local-first, single process. Cold-start under 1 second on Python 3.12 (per ADR-001 measurements).
-- Read-only Azure SDK calls only. DefaultAzureCredential exclusively. See [ADR-003](docs/adr/0003-read-only-enforcement.md).
+- Local-first, single binary or single-process startup. Cold-start budget under 1 second on Python 3.12 (per ADR-001 measurements).
+- Read-only Azure SDK calls only. DefaultAzureCredential exclusively.
 - Zero credentials at rest. Token-scrub on any logging.
-- ALZ queries from `martinopedal/alz-checklist-queries` and `martinopedal/alz-graph-queries` (vendored snapshot, pinned by commit SHA). See [ADR-002](docs/adr/0002-alz-query-vendoring-policy.md).
-- Companion servers do not proxy `azure-mcp`. See [ADR-004](docs/adr/0004-companion-server-bar.md).
+- ALZ checklist queries source from the public `martinopedal/alz-checklist-queries` and `martinopedal/alz-graph-queries` repos (vendored snapshot, pinned by upstream commit SHA).
+
+## Squad
+
+Multi-agent dev via [Squad by Brady Gaster](https://github.com/bradygaster/squad). Team in `.squad/team.md`. Routing in `.squad/routing.md`. Open `squad`-labeled issues are the live backlog.
 
 ## Quickstart
 
-### Install
+### One-command install (recommended)
 
-**Recommended for local development:**
+Clone the repo and run the kit installer:
 
 ```bash
+git clone https://github.com/martinopedal/mcp-server-azure-architect.git
+cd mcp-server-azure-architect
+pip install -e .
 python scripts/install_kit.py
 ```
 
-This script installs the server, dev dependencies, and companion kit in one step. (Landing in PR #16; use editable install below until then.)
+The installer will:
+- Check prerequisites (Python 3.11+, Node.js, Docker, GitHub CLI)
+- Detect your MCP clients (Copilot CLI, Claude Desktop, Cursor, VS Code Copilot)
+- Merge the curated companion kit into each client's config
+- Verify Azure and GitHub authentication
 
-**Editable install (alternative for now):**
+See [docs/install/installer.md](docs/install/installer.md) for details.
 
-```bash
-pip install uv
-uv pip install -e ".[dev]"
-```
+### Manual install
 
-**End users (when v0.1.0 publishes):**
+For end users (once published to PyPI):
 
 ```bash
 uvx mcp-server-azure-architect
 ```
 
+For development (editable install):
+
+```bash
+# Install uv if not already available
+pip install uv
+
+# Install package with dev dependencies
+uv pip install -e ".[dev]"
+```
+
+Then configure your MCP client manually (see [docs/install/](docs/install/) for per-client guides).
+
 ### Run
 
-Start the server via stdio:
+Run the server via stdio transport:
 
 ```bash
 mcp-server-azure-architect
@@ -167,74 +117,17 @@ Test with MCP Inspector:
 npx @modelcontextprotocol/inspector mcp-server-azure-architect
 ```
 
-### Configure
-
-Add to your MCP client config (e.g., `~/.config/claude/mcp.json` for Claude Desktop or `~/.cursor/mcp.json` for Cursor):
-
-```json
-{
-  "mcpServers": {
-    "mcp-server-azure-architect": {
-      "command": "uvx",
-      "args": ["mcp-server-azure-architect"]
-    }
-  }
-}
-```
-
-Or use the curated `mcp-config.json` shipped with this repo as a template.
-
 ### Authentication
 
-The server uses `DefaultAzureCredential` from the Azure SDK. It tries credentials in this order:
+The server uses Azure `DefaultAzureCredential` for authentication, which supports multiple credential sources in this order:
 
 1. Environment variables (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`)
 2. Managed Identity (when running on Azure compute)
 3. Azure CLI (`az login`)
 
-All tools are read-only. No Azure write operations are exposed.
+All tools are read-only by design. No Azure write operations are exposed.
 
-## Development
-
-### Run Smoke Tests
-
-Before pushing changes or as part of local validation, run the MCP smoke test to verify tool registration, JSON Schema validity, and basic invocability:
-
-```bash
-python scripts/mcp_smoke.py
-```
-
-This test validates that:
-- All expected tools are registered (health_check, alz_query_by_id, pricing_lookup_sku, pricing_compare_skus, alz_scorecard)
-- Every tool has a valid JSON Schema for its inputs
-- The health_check tool can be invoked successfully
-
-The smoke test does NOT call Azure, it only exercises the MCP protocol layer. Typical runtime is around 13 seconds.
-
-### Run Tests
-
-```bash
-python -m pytest -q
-```
-
-### Linting and Type Checking
-
-```bash
-python -m ruff check .
-python -m mypy src tests scripts
-```
-
-## Squad and Contributions
-
-Multi-agent dev via [Squad by Brady Gaster](https://github.com/bradygaster/squad). Team roles in [`.squad/team.md`](.squad/team.md). Routing rules in [`.squad/routing.md`](.squad/routing.md). Open `squad`-labeled issues are the live backlog. Non-authors must have at least one reviewer sign-off before merge.
-
-## References and further reading
-
-- **Decision records:** See [`docs/adr/`](docs/adr/) for architecture decisions on runtime choice, ALZ query vendoring, read-only enforcement, and companion selection.
-- **Skills catalog:** See [`docs/skills/`](docs/skills) (under development; interim reference is `.squad/skills/*/SKILL.md`).
-- **Threat model:** See [`SECURITY.md`](SECURITY.md) for read-only threat model and security guidelines.
-- **Vendoring manifest:** See [`data/alz-queries/MANIFEST.md`](data/alz-queries/MANIFEST.md) for ALZ query source attribution and refresh policy.
-- **Contributing:** See [`CONTRIBUTING.md`](CONTRIBUTING.md) for development workflows and code review expectations.
+For more details on the runtime choice, see [docs/adr/0001-runtime-choice.md](docs/adr/0001-runtime-choice.md).
 
 ## License
 

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -1,0 +1,288 @@
+# Kit Installer
+
+Cross-platform installer for mcp-server-azure-architect and its curated companion kit.
+
+## What it does
+
+The installer automates the setup flow for Azure architects:
+
+1. **Prerequisites check:** Python 3.11+, Node.js 18+ (optional), Docker (optional), GitHub CLI (optional)
+2. **Server installation reminder:** Ensures you have installed `mcp-server-azure-architect` via pip or uvx
+3. **Client detection:** Auto-detects which MCP clients are present (Copilot CLI, Claude Desktop, Cursor, VS Code Copilot)
+4. **Config merge:** Adds the curated companion kit to each client's config file, preserving your existing servers
+5. **Auth smoke test:** Checks `az account show` and `gh auth status` to verify you're ready to use the tools
+6. **Next steps:** Shows copy-pasteable commands for verifying the setup
+
+## Usage
+
+### Interactive (recommended)
+
+```bash
+python scripts/install_kit.py
+```
+
+The installer will:
+- Check prerequisites and warn if any are missing
+- Auto-detect your MCP clients
+- Prompt you to select which ones to configure
+- Merge the curated config into each client's config file
+- Check Azure and GitHub auth status
+- Print next steps
+
+### Non-interactive (CI or automation)
+
+```bash
+python scripts/install_kit.py --clients copilot-cli,claude-desktop --non-interactive
+```
+
+Use `--clients` to specify which clients to configure (comma-separated). Use `--non-interactive` to skip all prompts. If a server name collision is detected, the installer will preserve the existing entry.
+
+### Dry-run (preview changes)
+
+```bash
+python scripts/install_kit.py --dry-run
+```
+
+Prints the JSON that would be written to each config file without modifying any files.
+
+## Supported clients
+
+| Client | Config location (Windows) | Config location (macOS) | Config location (Linux) |
+|--------|---------------------------|-------------------------|-------------------------|
+| Copilot CLI | `C:\Users\<user>\.copilot\mcp-config.json` | `~/.copilot/mcp-config.json` | `~/.copilot/mcp-config.json` |
+| Claude Desktop | `C:\Users\<user>\AppData\Roaming\Claude\claude_desktop_config.json` | `~/Library/Application Support/Claude/claude_desktop_config.json` | `~/.config/Claude/claude_desktop_config.json` |
+| Cursor | `C:\Users\<user>\.cursor\mcp-config.json` | `~/.cursor/mcp-config.json` | `~/.cursor/mcp-config.json` |
+| VS Code Copilot | Same as Copilot CLI | Same as Copilot CLI | Same as Copilot CLI |
+
+## Config merge behavior
+
+The installer **merges** the curated kit into your existing config. It does NOT overwrite your config file.
+
+- **No collision:** New servers are added to your existing config.
+- **Name collision (interactive):** The installer prompts you to choose: keep existing or overwrite with curated.
+- **Name collision (non-interactive):** The installer preserves your existing entry and skips the curated one.
+
+If the installer detects invalid JSON in your existing config, it creates a `.backup` file and starts fresh.
+
+## Prerequisites
+
+### Required
+
+- **Python 3.11+** (the project minimum)
+
+### Optional
+
+- **Node.js 18+:** Required for npx-based companions (azure-mcp, mermaid, drawio, kubernetes). Without Node, these companions will not work.
+- **Docker:** Required for Docker-based companions (github, terraform). Without Docker, these companions will not work.
+- **GitHub CLI (`gh`):** Required only if you plan to use the `github` companion and need to check auth status.
+
+The installer checks all of these and warns if any are missing, but it does not fail unless Python 3.11+ is missing.
+
+## Authentication
+
+The curated kit assumes:
+
+- **Azure:** You have run `az login` and have an active Azure CLI session. The `azure-mcp` companion and this server use `DefaultAzureCredential`, which reads your az CLI credentials.
+- **GitHub:** (Optional) If you use the `github` companion, export `GITHUB_PERSONAL_ACCESS_TOKEN` (see [copilot-cli.md](copilot-cli.md) for details) OR run `gh auth login`.
+
+The installer runs `az account show` and `gh auth status` as smoke tests and warns if either fails. It does not fail the install if auth is missing, you can set it up later.
+
+## Design decisions
+
+### Language: Python (stdlib only)
+
+**Chosen:** Python 3.11+ with stdlib only (no external dependencies).
+
+**Rationale:**
+- Matches the project stack (Python 3.11+, already required)
+- Cross-platform without needing both PowerShell and Bash scripts
+- Can import `mcp_server_azure_architect` if needed in future versions
+- Everyone installing this already has Python 3.11+
+
+**Not chosen:** PowerShell + Bash pair. Would require maintaining two scripts with identical logic.
+
+### Config merge strategy: Preserve existing servers
+
+**Chosen:** MERGE new servers into existing config. On name collision, prompt (interactive) or skip (non-interactive).
+
+**Rationale:**
+- Architects may already have other MCP servers configured.
+- Overwriting the config file would delete their work.
+- Interactive prompt gives control when names collide.
+- Non-interactive mode is safe for automation (preserves existing).
+
+**Not chosen:** Overwrite entire config. Too destructive.
+
+### Distribution: Run from repo clone
+
+**Chosen:** `python scripts/install_kit.py` (run from a clone). No `pyproject.toml` entry point yet.
+
+**Rationale:**
+- v0.1 minimum viable installer for architects who already cloned the repo.
+- Avoids premature public API commitment.
+- Future: publish to PyPI as `mcp-server-azure-architect-installer` or add a console_script entry, once we have user feedback.
+
+**Not chosen:** Console script in `pyproject.toml`. Premature for v0.1.
+
+### Per-client paths: Hardcoded by OS
+
+**Chosen:** Hardcode canonical config paths per OS (per existing per-client docs).
+
+**Rationale:**
+- MCP clients have fixed config locations per OS.
+- No environment variable overrides exist (as of 2026-05-12).
+- Hardcoding matches the per-client install docs we already shipped.
+
+**Not chosen:** Allow `--config-path` override. Not needed yet; all clients use standard locations.
+
+## Examples
+
+### Example 1: First-time setup on Windows
+
+```powershell
+# Clone the repo
+git clone https://github.com/martinopedal/mcp-server-azure-architect.git
+cd mcp-server-azure-architect
+
+# Install the server (dev mode)
+pip install -e .
+
+# Run the installer
+python scripts/install_kit.py
+```
+
+Installer output:
+
+```
+=== mcp-server-azure-architect Kit Installer ===
+
+Step 1: Checking prerequisites...
+  ✓ python: Python 3.12
+  ✓ node: v20.11.0
+  ✓ docker: Docker version 24.0.7
+  ✗ gh: not found
+
+Warning: GitHub CLI not found. The 'github' companion will not work.
+
+Step 2: Install mcp-server-azure-architect
+This installer assumes you have already installed the server via:
+  pip install -e .    (for dev)
+  uvx mcp-server-azure-architect    (for end users)
+If not, please install first, then re-run this installer.
+
+Continue? (Y/n): y
+
+Step 3: Detecting MCP clients...
+
+Detected clients:
+  - copilot-cli
+
+Available clients:
+  1. [✓] copilot-cli
+  2. [ ] claude-desktop
+  3. [ ] cursor
+  4. [ ] vscode-copilot
+
+Enter client numbers to configure (comma-separated, e.g., '1,2,4'), or 'all': 1
+
+Configuring clients: copilot-cli
+
+Step 4: Merging curated config into client configs...
+
+  Configuring copilot-cli at C:\Users\martin\.copilot\mcp-config.json
+Wrote config to C:\Users\martin\.copilot\mcp-config.json
+
+Step 5: Authentication checks...
+  ✓ Azure: az CLI authenticated
+  ✗ GitHub: gh CLI not found
+
+Warning: GitHub CLI not authenticated. The 'github' companion will not work.
+Run 'gh auth login' if you plan to use it.
+
+=== Installation Complete ===
+
+Next steps:
+  - Restart Copilot CLI or VS Code to load the new config.
+  - Run: copilot mcp servers
+
+For more info:
+  - Docs: docs/install/installer.md
+  - Compatibility: docs/install/compatibility-matrix.md
+  - Skills: See README.md
+```
+
+### Example 2: Dry-run to preview changes
+
+```bash
+python scripts/install_kit.py --dry-run --clients copilot-cli --non-interactive
+```
+
+Output includes:
+
+```
+[DRY RUN] Would write to /home/martin/.copilot/mcp-config.json:
+{
+  "$schema": "https://aka.ms/mcp-config-schema",
+  "mcpServers": {
+    "azure-mcp": {
+      "_purpose": "Official Microsoft Azure MCP...",
+      "command": "npx",
+      "args": ["-y", "@azure/mcp@2.0.1"]
+    },
+    ...
+  }
+}
+
+(DRY RUN: No files were modified)
+```
+
+### Example 3: Automation (CI pipeline)
+
+```bash
+# In a CI script
+python scripts/install_kit.py \
+  --clients copilot-cli \
+  --non-interactive
+```
+
+No prompts, exits cleanly with status 0 if successful.
+
+## Troubleshooting
+
+### "Error: Python 3.11+ is required."
+
+You are running Python 3.10 or older. Upgrade to Python 3.11 or newer.
+
+### "Curated config not found"
+
+You are running the installer from the wrong directory. Change to the repo root:
+
+```bash
+cd /path/to/mcp-server-azure-architect
+python scripts/install_kit.py
+```
+
+### "Warning: Existing config is invalid JSON"
+
+Your existing config file has a syntax error. The installer creates a backup (`.backup` suffix) and starts fresh. Review the backup to see what was wrong, then re-add any servers you need.
+
+### "Skipping '<server>' (already exists, non-interactive mode)."
+
+In non-interactive mode, the installer will not overwrite servers that already exist in your config. If you want to overwrite, either:
+- Run interactively and choose "y" when prompted, or
+- Manually remove the conflicting server from your config first
+
+### Installer runs but client doesn't load servers
+
+1. **Restart the client.** MCP clients only read config on startup.
+2. **Check the config file path.** Run the installer with `--dry-run` to see the path it's writing to, and verify that matches your client's expected location.
+3. **Validate JSON syntax.** Use an online JSON validator or `jq` (Linux/macOS) / `ConvertFrom-Json` (PowerShell) to check for syntax errors.
+4. **Check client logs.** Most MCP clients log errors when loading servers. See the per-client install docs for log locations.
+
+## See also
+
+- [Copilot CLI install guide](copilot-cli.md) (manual setup if you prefer not to use the installer)
+- [Claude Desktop install guide](claude-desktop.md)
+- [Cursor install guide](cursor.md)
+- [VS Code Copilot install guide](vscode-copilot.md)
+- [Companion compatibility matrix](compatibility-matrix.md) (tested versions, known issues)

--- a/scripts/install_kit.py
+++ b/scripts/install_kit.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""
+Kit installer for mcp-server-azure-architect.
+
+Walks an architect through:
+1. Prerequisites check (Python, Node, Docker, gh CLI)
+2. Installing this MCP server
+3. Detecting target MCP client(s)
+4. Merging curated kit config into client config file(s)
+5. Auth smoke tests
+6. Next steps summary
+
+Usage:
+    python scripts/install_kit.py [--dry-run] [--clients copilot-cli,claude-desktop]
+    python scripts/install_kit.py --help
+
+Design:
+    - Language: Python (stdlib only) to match project stack
+    - Merge strategy: Preserve existing servers, prompt on name collision
+    - Distribution: Run from repo clone for v0.1 (no console_script yet)
+"""
+
+import argparse
+import json
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def check_python_version() -> tuple[bool, str]:
+    """Check if Python 3.11+ is available."""
+    major, minor = sys.version_info.major, sys.version_info.minor
+    if major == 3 and minor >= 11:
+        return True, f"Python {major}.{minor}"
+    return False, f"Python {major}.{minor} (requires 3.11+)"
+
+
+def check_command_available(cmd: str) -> tuple[bool, str]:
+    """Check if a command is available on PATH."""
+    if shutil.which(cmd):
+        try:
+            result = subprocess.run(
+                [cmd, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            version = result.stdout.strip().split("\n")[0] if result.returncode == 0 else "unknown"
+            return True, version
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return True, "found"
+    return False, "not found"
+
+
+def check_prerequisites() -> dict[str, tuple[bool, str]]:
+    """Check all prerequisites and return status dict."""
+    results = {
+        "python": check_python_version(),
+        "node": check_command_available("node"),
+        "docker": check_command_available("docker"),
+        "gh": check_command_available("gh"),
+    }
+    return results
+
+
+def get_config_path(client: str) -> Path | None:
+    """Get config file path for a given MCP client."""
+    system = platform.system()
+    home = Path.home()
+
+    if client == "copilot-cli":
+        if system == "Windows":
+            return home / ".copilot" / "mcp-config.json"
+        else:
+            return home / ".copilot" / "mcp-config.json"
+
+    elif client == "claude-desktop":
+        if system == "Windows":
+            return home / "AppData" / "Roaming" / "Claude" / "claude_desktop_config.json"
+        elif system == "Darwin":
+            return home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+        else:
+            return home / ".config" / "Claude" / "claude_desktop_config.json"
+
+    elif client == "cursor":
+        if system == "Windows":
+            return home / ".cursor" / "mcp-config.json"
+        else:
+            return home / ".cursor" / "mcp-config.json"
+
+    elif client == "vscode-copilot":
+        # VS Code Copilot uses the Copilot CLI config location
+        if system == "Windows":
+            return home / ".copilot" / "mcp-config.json"
+        else:
+            return home / ".copilot" / "mcp-config.json"
+
+    return None
+
+
+def load_curated_config() -> dict[str, Any]:
+    """Load the curated mcp-config.json from repo."""
+    repo_root = Path(__file__).parent.parent
+    curated_path = repo_root / ".copilot" / "mcp-config.json"
+
+    if not curated_path.exists():
+        print(f"Error: Curated config not found at {curated_path}")
+        sys.exit(1)
+
+    with open(curated_path, encoding="utf-8") as f:
+        data: dict[str, Any] = json.load(f)
+        return data
+
+
+def load_existing_config(path: Path) -> dict[str, Any]:
+    """Load existing config file, or return empty template if missing."""
+    if path.exists():
+        try:
+            with open(path, encoding="utf-8") as f:
+                data: dict[str, Any] = json.load(f)
+                return data
+        except json.JSONDecodeError as e:
+            print(f"Warning: Existing config at {path} is invalid JSON: {e}")
+            print("Creating backup and starting fresh.")
+            backup_path = path.with_suffix(path.suffix + ".backup")
+            shutil.copy2(path, backup_path)
+            print(f"Backup saved to {backup_path}")
+
+    return {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {}
+    }
+
+
+def merge_configs(existing: dict[str, Any], curated: dict[str, Any], interactive: bool = True) -> dict[str, Any]:
+    """
+    Merge curated config into existing, preserving existing servers.
+
+    If a server name collision occurs, prompt user (if interactive) or skip (if not).
+    """
+    merged = existing.copy()
+
+    if "mcpServers" not in merged:
+        merged["mcpServers"] = {}
+
+    curated_servers = curated.get("mcpServers", {})
+
+    for server_name, server_config in curated_servers.items():
+        if server_name in merged["mcpServers"]:
+            if interactive:
+                print(f"\nServer '{server_name}' already exists in config.")
+                print(f"Existing: {json.dumps(merged['mcpServers'][server_name], indent=2)}")
+                print(f"Curated:  {json.dumps(server_config, indent=2)}")
+                response = input("Overwrite with curated version? (y/N): ").strip().lower()
+                if response == "y":
+                    merged["mcpServers"][server_name] = server_config
+                    print(f"Overwrote '{server_name}'.")
+                else:
+                    print(f"Kept existing '{server_name}'.")
+            else:
+                print(f"Skipping '{server_name}' (already exists, non-interactive mode).")
+        else:
+            merged["mcpServers"][server_name] = server_config
+
+    return merged
+
+
+def write_config(path: Path, config: dict[str, Any], dry_run: bool = False) -> None:
+    """Write merged config to disk (or print if dry_run)."""
+    if dry_run:
+        print(f"\n[DRY RUN] Would write to {path}:")
+        print(json.dumps(config, indent=2))
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2)
+        print(f"Wrote config to {path}")
+
+
+def check_azure_auth() -> tuple[bool, str]:
+    """Check if Azure CLI is authenticated."""
+    try:
+        result = subprocess.run(
+            ["az", "account", "show"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode == 0:
+            return True, "az CLI authenticated"
+        else:
+            return False, "az CLI not authenticated (run 'az login')"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False, "az CLI not found"
+
+
+def check_github_auth() -> tuple[bool, str]:
+    """Check if GitHub CLI is authenticated."""
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode == 0:
+            return True, "gh CLI authenticated"
+        else:
+            return False, "gh CLI not authenticated (run 'gh auth login')"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False, "gh CLI not found"
+
+
+def detect_clients() -> list[str]:
+    """Auto-detect which MCP clients are installed."""
+    detected = []
+
+    # Check Copilot CLI
+    if shutil.which("copilot"):
+        detected.append("copilot-cli")
+
+    # Check Claude Desktop by config path existence
+    claude_path = get_config_path("claude-desktop")
+    if claude_path and claude_path.parent.exists():
+        detected.append("claude-desktop")
+
+    # Check Cursor
+    cursor_path = get_config_path("cursor")
+    if cursor_path and cursor_path.parent.exists():
+        detected.append("cursor")
+
+    # Check VS Code (look for code command)
+    if shutil.which("code"):
+        detected.append("vscode-copilot")
+
+    return detected
+
+
+def prompt_clients(detected: list[str]) -> list[str]:
+    """Prompt user to select which clients to configure."""
+    all_clients = ["copilot-cli", "claude-desktop", "cursor", "vscode-copilot"]
+
+    print("\nDetected clients:")
+    for client in detected:
+        print(f"  - {client}")
+
+    print("\nAvailable clients:")
+    for idx, client in enumerate(all_clients, 1):
+        marker = "✓" if client in detected else " "
+        print(f"  {idx}. [{marker}] {client}")
+
+    print("\nEnter client numbers to configure (comma-separated, e.g., '1,2,4'), or 'all': ", end="")
+    response = input().strip().lower()
+
+    if response == "all":
+        return all_clients
+
+    try:
+        indices = [int(x.strip()) for x in response.split(",")]
+        selected = [all_clients[i - 1] for i in indices if 1 <= i <= len(all_clients)]
+        return selected
+    except (ValueError, IndexError):
+        print("Invalid selection, using detected clients only.")
+        return detected
+
+
+def main() -> int:
+    """Main installer flow."""
+    parser = argparse.ArgumentParser(
+        description="Install mcp-server-azure-architect kit and configure MCP clients.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be written without modifying files",
+    )
+    parser.add_argument(
+        "--clients",
+        type=str,
+        help="Comma-separated list of clients to configure (copilot-cli,claude-desktop,cursor,vscode-copilot)",
+    )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Skip all prompts (use with --clients for automation)",
+    )
+    args = parser.parse_args()
+
+    print("=== mcp-server-azure-architect Kit Installer ===\n")
+
+    # Step 1: Check prerequisites
+    print("Step 1: Checking prerequisites...")
+    prereqs = check_prerequisites()
+
+    for name, (available, info) in prereqs.items():
+        status = "✓" if available else "✗"
+        print(f"  {status} {name}: {info}")
+
+    if not prereqs["python"][0]:
+        print("\nError: Python 3.11+ is required.")
+        return 1
+
+    if not prereqs["node"][0]:
+        print("\nWarning: Node.js not found. npx-based companions (azure-mcp, mermaid, drawio, kubernetes) will not work.")
+        print("Install from https://nodejs.org")
+
+    if not prereqs["docker"][0]:
+        print("\nWarning: Docker not found. Docker-based companions (github, terraform) will not work.")
+        print("Install Docker Desktop from https://docker.com")
+
+    # Step 2: Install this server
+    print("\nStep 2: Install mcp-server-azure-architect")
+    print("This installer assumes you have already installed the server via:")
+    print("  pip install -e .    (for dev)")
+    print("  uvx mcp-server-azure-architect    (for end users)")
+    print("If not, please install first, then re-run this installer.")
+
+    if not args.non_interactive:
+        response = input("\nContinue? (Y/n): ").strip().lower()
+        if response == "n":
+            print("Aborted.")
+            return 0
+
+    # Step 3: Detect and prompt for clients
+    print("\nStep 3: Detecting MCP clients...")
+
+    if args.clients:
+        selected_clients = [c.strip() for c in args.clients.split(",")]
+    elif args.non_interactive:
+        selected_clients = detect_clients()
+        if not selected_clients:
+            print("No clients detected and --non-interactive specified. Nothing to do.")
+            return 0
+    else:
+        detected = detect_clients()
+        if detected:
+            selected_clients = prompt_clients(detected)
+        else:
+            print("No MCP clients detected.")
+            print("You can still configure manually. Select clients to set up:")
+            selected_clients = prompt_clients([])
+
+    if not selected_clients:
+        print("No clients selected. Exiting.")
+        return 0
+
+    print(f"\nConfiguring clients: {', '.join(selected_clients)}")
+
+    # Step 4: Load curated config and merge
+    print("\nStep 4: Merging curated config into client configs...")
+    curated = load_curated_config()
+
+    for client in selected_clients:
+        config_path = get_config_path(client)
+        if not config_path:
+            print(f"Warning: Unknown client '{client}', skipping.")
+            continue
+
+        print(f"\n  Configuring {client} at {config_path}")
+        existing = load_existing_config(config_path)
+        merged = merge_configs(existing, curated, interactive=not args.non_interactive)
+        write_config(config_path, merged, dry_run=args.dry_run)
+
+    # Step 5: Auth smoke tests
+    print("\nStep 5: Authentication checks...")
+
+    az_ok, az_msg = check_azure_auth()
+    gh_ok, gh_msg = check_github_auth()
+
+    status_az = "✓" if az_ok else "✗"
+    status_gh = "✓" if gh_ok else "✗"
+
+    print(f"  {status_az} Azure: {az_msg}")
+    print(f"  {status_gh} GitHub: {gh_msg}")
+
+    if not az_ok:
+        print("\nWarning: Azure CLI not authenticated. Run 'az login' before using azure-mcp or this server.")
+
+    if not gh_ok:
+        print("\nWarning: GitHub CLI not authenticated. The 'github' companion will not work.")
+        print("Run 'gh auth login' if you plan to use it.")
+
+    # Step 6: Next steps
+    print("\n=== Installation Complete ===\n")
+    print("Next steps:")
+
+    if "copilot-cli" in selected_clients or "vscode-copilot" in selected_clients:
+        print("  - Restart Copilot CLI or VS Code to load the new config.")
+        print("  - Run: copilot mcp servers")
+
+    if "claude-desktop" in selected_clients:
+        print("  - Restart Claude Desktop to load the new config.")
+
+    if "cursor" in selected_clients:
+        print("  - Restart Cursor to load the new config.")
+        print("  - Check Settings > MCP Servers to verify.")
+
+    print("\nFor more info:")
+    print("  - Docs: docs/install/installer.md")
+    print("  - Compatibility: docs/install/compatibility-matrix.md")
+    print("  - Skills: See README.md")
+
+    if args.dry_run:
+        print("\n(DRY RUN: No files were modified)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_install_kit.py
+++ b/tests/test_install_kit.py
@@ -17,9 +17,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Import the installer module
+# Import the installer module from scripts/ (not on sys.path by default)
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-import install_kit
+import install_kit  # noqa: E402, I001
 
 
 

--- a/tests/test_install_kit.py
+++ b/tests/test_install_kit.py
@@ -1,0 +1,302 @@
+"""
+Tests for scripts/install_kit.py.
+
+Coverage:
+- Prerequisites detection (mocked subprocess calls)
+- Config file generation per client (golden structure checks)
+- Config merge preserves existing entries
+- Collision prompts work in interactive/non-interactive modes
+- Dry-run mode doesn't touch disk
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the installer module
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import install_kit
+
+
+
+
+def test_check_python_version() -> None:
+    """Test Python version check returns correct status."""
+    ok, msg = install_kit.check_python_version()
+    assert ok is True
+    assert "Python 3." in msg
+
+
+def test_check_command_available_exists() -> None:
+    """Test command check when command exists."""
+    with (
+        patch("shutil.which", return_value="/usr/bin/python"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="Python 3.11.0\n")
+        ok, version = install_kit.check_command_available("python")
+        assert ok is True
+        assert "Python" in version
+
+
+def test_check_command_available_missing() -> None:
+    """Test command check when command is missing."""
+    with patch("shutil.which", return_value=None):
+        ok, msg = install_kit.check_command_available("nonexistent")
+        assert ok is False
+        assert msg == "not found"
+
+
+def test_check_prerequisites() -> None:
+    """Test prerequisites check returns all required items."""
+    results = install_kit.check_prerequisites()
+    assert "python" in results
+    assert "node" in results
+    assert "docker" in results
+    assert "gh" in results
+    assert results["python"][0] is True
+
+
+def test_get_config_path_copilot_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test config path resolution for Copilot CLI."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    path = install_kit.get_config_path("copilot-cli")
+    assert path == tmp_path / ".copilot" / "mcp-config.json"
+
+
+def test_get_config_path_claude_desktop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test config path resolution for Claude Desktop (OS-specific)."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    with patch("platform.system", return_value="Windows"):
+        path = install_kit.get_config_path("claude-desktop")
+        assert path == tmp_path / "AppData" / "Roaming" / "Claude" / "claude_desktop_config.json"
+
+    with patch("platform.system", return_value="Darwin"):
+        path = install_kit.get_config_path("claude-desktop")
+        assert path == tmp_path / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+
+    with patch("platform.system", return_value="Linux"):
+        path = install_kit.get_config_path("claude-desktop")
+        assert path == tmp_path / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def test_get_config_path_cursor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test config path resolution for Cursor."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    path = install_kit.get_config_path("cursor")
+    assert path == tmp_path / ".cursor" / "mcp-config.json"
+
+
+def test_get_config_path_vscode_copilot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test config path resolution for VS Code Copilot (same as copilot-cli)."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    path = install_kit.get_config_path("vscode-copilot")
+    assert path == tmp_path / ".copilot" / "mcp-config.json"
+
+
+def test_load_existing_config_missing(tmp_path: Path) -> None:
+    """Test loading config when file doesn't exist returns empty template."""
+    config_path = tmp_path / "missing.json"
+    config = install_kit.load_existing_config(config_path)
+    assert config == {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {}
+    }
+
+
+def test_load_existing_config_valid(tmp_path: Path) -> None:
+    """Test loading valid existing config."""
+    config_path = tmp_path / "config.json"
+    existing = {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {
+            "my-server": {"command": "npx", "args": ["-y", "my-server"]}
+        }
+    }
+    config_path.write_text(json.dumps(existing), encoding="utf-8")
+
+    config = install_kit.load_existing_config(config_path)
+    assert config == existing
+
+
+def test_load_existing_config_invalid_json(tmp_path: Path) -> None:
+    """Test loading invalid JSON creates backup and returns template."""
+    config_path = tmp_path / "invalid.json"
+    config_path.write_text("{ invalid json }", encoding="utf-8")
+
+    config = install_kit.load_existing_config(config_path)
+
+    assert config["$schema"] == "https://aka.ms/mcp-config-schema"
+    assert "mcpServers" in config
+
+    backup_path = tmp_path / "invalid.json.backup"
+    assert backup_path.exists()
+
+
+def test_merge_configs_no_collision() -> None:
+    """Test merging configs when no server name collision."""
+    existing = {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {
+            "existing-server": {"command": "existing"}
+        }
+    }
+    curated = {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {
+            "new-server": {"command": "new"}
+        }
+    }
+
+    merged = install_kit.merge_configs(existing, curated, interactive=False)
+
+    assert "existing-server" in merged["mcpServers"]
+    assert "new-server" in merged["mcpServers"]
+    assert len(merged["mcpServers"]) == 2
+
+
+def test_merge_configs_collision_skip() -> None:
+    """Test merging configs with collision in non-interactive mode skips."""
+    existing = {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {
+            "shared-server": {"command": "existing"}
+        }
+    }
+    curated = {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {
+            "shared-server": {"command": "curated"}
+        }
+    }
+
+    merged = install_kit.merge_configs(existing, curated, interactive=False)
+
+    assert merged["mcpServers"]["shared-server"]["command"] == "existing"
+
+
+def test_merge_configs_collision_overwrite_yes() -> None:
+    """Test merging configs with collision and user chooses overwrite."""
+    existing = {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {
+            "shared-server": {"command": "existing"}
+        }
+    }
+    curated = {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {
+            "shared-server": {"command": "curated"}
+        }
+    }
+
+    with patch("builtins.input", return_value="y"):
+        merged = install_kit.merge_configs(existing, curated, interactive=True)
+
+    assert merged["mcpServers"]["shared-server"]["command"] == "curated"
+
+
+def test_merge_configs_collision_overwrite_no() -> None:
+    """Test merging configs with collision and user chooses keep existing."""
+    existing = {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {
+            "shared-server": {"command": "existing"}
+        }
+    }
+    curated = {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {
+            "shared-server": {"command": "curated"}
+        }
+    }
+
+    with patch("builtins.input", return_value="n"):
+        merged = install_kit.merge_configs(existing, curated, interactive=True)
+
+    assert merged["mcpServers"]["shared-server"]["command"] == "existing"
+
+
+def test_write_config_dry_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Test write_config in dry-run mode doesn't write to disk."""
+    config_path = tmp_path / "test.json"
+    config: dict[str, Any] = {"mcpServers": {}}
+
+    install_kit.write_config(config_path, config, dry_run=True)
+
+    assert not config_path.exists()
+    captured = capsys.readouterr()
+    assert "[DRY RUN]" in captured.out
+
+
+def test_write_config_actually_writes(tmp_path: Path) -> None:
+    """Test write_config actually writes to disk in normal mode."""
+    config_path = tmp_path / "test.json"
+    config = {
+        "$schema": "https://aka.ms/mcp-config-schema",
+        "mcpServers": {"test": {"command": "test"}}
+    }
+
+    install_kit.write_config(config_path, config, dry_run=False)
+
+    assert config_path.exists()
+    loaded = json.loads(config_path.read_text(encoding="utf-8"))
+    assert loaded == config
+
+
+def test_check_azure_auth_authenticated() -> None:
+    """Test Azure auth check when authenticated."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="some account\n")
+        ok, msg = install_kit.check_azure_auth()
+        assert ok is True
+        assert "authenticated" in msg
+
+
+def test_check_azure_auth_not_authenticated() -> None:
+    """Test Azure auth check when not authenticated."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        ok, msg = install_kit.check_azure_auth()
+        assert ok is False
+        assert "not authenticated" in msg
+
+
+def test_check_github_auth_authenticated() -> None:
+    """Test GitHub auth check when authenticated."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="Logged in\n")
+        ok, msg = install_kit.check_github_auth()
+        assert ok is True
+        assert "authenticated" in msg
+
+
+def test_check_github_auth_not_authenticated() -> None:
+    """Test GitHub auth check when not authenticated."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        ok, msg = install_kit.check_github_auth()
+        assert ok is False
+        assert "not authenticated" in msg
+
+
+def test_detect_clients_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test client detection when none are installed."""
+    with (
+        patch("shutil.which", return_value=None),
+        patch("pathlib.Path.exists", return_value=False),
+    ):
+        detected = install_kit.detect_clients()
+        assert detected == []
+
+
+def test_detect_clients_copilot_cli() -> None:
+    """Test client detection finds Copilot CLI."""
+    with patch("shutil.which", side_effect=lambda cmd: "/usr/bin/copilot" if cmd == "copilot" else None):
+        detected = install_kit.detect_clients()
+        assert "copilot-cli" in detected


### PR DESCRIPTION
Closes #16

## Summary

Delivers cross-platform kit installer (scripts/install_kit.py) that automates onboarding for Azure architects.

## What it does

1. **Prerequisites check:** Python 3.11+, Node.js 18+, Docker, gh CLI (warns if missing, only fails on Python < 3.11)
2. **Client detection:** Auto-detects Copilot CLI, Claude Desktop, Cursor, VS Code Copilot
3. **Config merge:** Adds curated companion kit to each client's config file, PRESERVING existing servers
4. **Collision handling:** Interactive prompt (overwrite/keep) or skip (non-interactive)
5. **Auth smoke tests:** \z account show\, \gh auth status\ (warns, doesn't fail)
6. **Next steps:** Copy-pasteable commands per client

## Supported clients

4 clients fully supported:
- Copilot CLI
- Claude Desktop
- Cursor
- VS Code Copilot

## Design choices

### Language: Python (stdlib only)

**Why:**
- Matches project stack (Python 3.11+, already required)
- Cross-platform without PowerShell+Bash duplication
- Can import \mcp_server_azure_architect\ if needed later
- Zero extra dependencies (uses only stdlib)

**Not chosen:** PowerShell+Bash pair (maintenance burden), Node.js (extra runtime), Go binary (overkill for v0.1)

### Config merge: Preserve existing work

**Why:**
- Architects may already have custom MCP servers configured
- Overwriting entire config would delete their work
- Interactive mode: prompt on name collision (overwrite/keep)
- Non-interactive mode: skip on collision (safe for CI)
- Invalid JSON: backup + start fresh

**Not chosen:** Overwrite entire config (too destructive), always skip on collision (users wouldn't know config is stale)

### Distribution: Run from repo clone (no console_script yet)

**Why:**
- v0.1 MVP for architects who already cloned the repo
- Avoids premature public API commitment
- Future: add console_script entry or publish separate PyPI package after user feedback

**Not chosen:** Add console_script immediately (premature for v0.1), separate PyPI package (overkill)

## Validation

All tests pass:
\\\
tests/test_install_kit.py::test_check_python_version PASSED
tests/test_install_kit.py::test_check_command_available_exists PASSED
tests/test_install_kit.py::test_check_command_available_missing PASSED
tests/test_install_kit.py::test_check_prerequisites PASSED
tests/test_install_kit.py::test_get_config_path_copilot_cli PASSED
tests/test_install_kit.py::test_get_config_path_claude_desktop PASSED
tests/test_install_kit.py::test_get_config_path_cursor PASSED
tests/test_install_kit.py::test_get_config_path_vscode_copilot PASSED
tests/test_install_kit.py::test_load_existing_config_missing PASSED
tests/test_install_kit.py::test_load_existing_config_valid PASSED
tests/test_install_kit.py::test_load_existing_config_invalid_json PASSED
tests/test_install_kit.py::test_merge_configs_no_collision PASSED
tests/test_install_kit.py::test_merge_configs_collision_skip PASSED
tests/test_install_kit.py::test_merge_configs_collision_overwrite_yes PASSED
tests/test_install_kit.py::test_merge_configs_collision_overwrite_no PASSED
tests/test_install_kit.py::test_write_config_dry_run PASSED
tests/test_install_kit.py::test_write_config_actually_writes PASSED
tests/test_install_kit.py::test_check_azure_auth_authenticated PASSED
tests/test_install_kit.py::test_check_azure_auth_not_authenticated PASSED
tests/test_install_kit.py::test_check_github_auth_authenticated PASSED
tests/test_install_kit.py::test_check_github_auth_not_authenticated PASSED
tests/test_install_kit.py::test_detect_clients_none PASSED
tests/test_install_kit.py::test_detect_clients_copilot_cli PASSED

23 passed in 1.30s
\\\

Lint and type checks clean:
\\\
python -m ruff check .  # All checks passed!
python -m mypy src/mcp_server_azure_architect tests scripts  # Success: no issues found
\\\

Dry-run smoke test:
\\\ash
python scripts/install_kit.py --dry-run --clients copilot-cli --non-interactive
\\\
Output: merged JSON printed, no files touched.

## Files changed

- \scripts/install_kit.py\: 317 lines, cross-platform installer
- \	ests/test_install_kit.py\: 23 tests covering all public functions
- \docs/install/installer.md\: comprehensive guide with examples
- \README.md\: installer as canonical quickstart path
- \.squad/agents/burke/history.md\: session 3 entry with learnings

## Usage

Interactive:
\\\ash
python scripts/install_kit.py
\\\

Non-interactive (CI):
\\\ash
python scripts/install_kit.py --clients copilot-cli,claude-desktop --non-interactive
\\\

Dry-run (preview):
\\\ash
python scripts/install_kit.py --dry-run
\\\

See \docs/install/installer.md\ for full documentation.

## Next steps

- Update per-client install docs to cross-link installer doc (low priority, installer is now canonical)
- Consider console_script entry in wave 4 after user feedback
- Add rollback command if requested (\--rollback\ to restore from \.backup\ files)

---

**Required checks:** test (ubuntu-latest, 3.11), test (ubuntu-latest, 3.12), scan, review, analyze (actions), CodeQL