### PR TITLE
docs(readme): Wave 5 comprehensive rewrite with tools, skills, architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,89 +2,160 @@
 
 > **Not an official Microsoft product.** This is a personal community tool that **complements** the official Microsoft [`azure-mcp`](https://github.com/microsoft/azure-mcp) server, it does not replace it.
 
-MCP server and Copilot CLI skills bundle for Azure architects. Native tools fill the architect-shaped gap above `azure-mcp`. A curated `mcp-config.json` ships alongside so an architect's "kit" (Microsoft Learn, mermaid, drawio, kubernetes, terraform companions) is one install.
+MCP server and Copilot CLI skills bundle for Azure architects. Native tools fill the architect-shaped gap above `azure-mcp`: named ALZ checklist queries by ID, ALZ readiness scorecard, pricing lookup and comparison. Curated companion kit (Microsoft Learn, mermaid, Terraform, Kubernetes, etc.) bundles with one install.
 
 ## Why this exists
 
-`azure-mcp` already exposes Azure Resource Graph, Quota, Advisor, Monitor, Policy, RBAC, AKS, App Service, and more as MCP tools. Use it directly for those.
+`azure-mcp` already exposes Azure Resource Graph, Advisor, Monitor, Policy, RBAC, AKS, and more as MCP tools. Use it directly for those.
 
 What architects still need that `azure-mcp` does **not** ship:
 
-- **Named ALZ checklist queries** (by checklist ID), not raw KQL.
-- **ALZ readiness scorecard** that composes many queries into one ranked, scored answer.
-- **Architect skills** that orchestrate the kit: a `design-review` skill that pulls current state via `azure-mcp`, gaps via this server, and renders a diagram via `mermaid-mcp`.
+- **Named ALZ checklist queries.** Look up by checklist ID (not raw KQL), get the query, source attribution, and pillar classification.
+- **ALZ readiness scorecard.** Run vendored ALZ queries against a subscription, get pass/fail/unknown per item plus aggregate by pillar.
+- **Azure pricing tools.** Look up retail pricing by SKU and region, compare SKU costs side by side.
+- **Architect orchestration skills.** A `design-review` skill that pulls current state via `azure-mcp`, gaps via this server, and renders diagrams via `mermaid-mcp`. Similar skills for migration planning and policy review.
 
-This server is **not a router or aggregator**. MCP clients already aggregate. We ship the missing tools and a curated companion config.
+This server is **not a router or aggregator.** MCP clients already aggregate. We ship the missing tools and a curated companion config.
 
-## What's in scope
+## Native tools (5)
 
-- A small MCP server exposing two native tool families: `alz_query_by_id` (catalog lookup) and `alz_scorecard` (composition + scoring).
-- Copilot CLI skills: `design-review`, `alz-gap-check`, `ingress-migration-plan`, `policy-as-code-suggest`.
-- A curated `mcp-config.json` for Copilot CLI, Claude Desktop, Cursor, and VS Code Copilot.
-- Read-only by default, end to end.
+| Tool | Purpose |
+|------|---------|
+| `health_check` | Check server health and version. One-line status response. |
+| `alz_query_by_id` | Vendored ALZ checklist query lookup by ID. Returns KQL text, source commit, and citation. Read-only snapshot scan, no Azure calls. |
+| `pricing_lookup_sku` | Azure retail pricing for one SKU in one region, one term. Calls public Retail Prices API (no auth). 24-hour cache. |
+| `pricing_compare_skus` | Compare retail pricing for multiple SKUs side by side. Useful for sizing trade-off review. Capped at 10 SKUs per call. |
+| `alz_scorecard` | Run vendored ALZ queries against a subscription via Azure Resource Graph. Returns per-item pass/fail/unknown plus aggregate by pillar. Capped at 25 queries per call. |
 
-## What's out of scope
+All tools are read-only. See [ADR-003](docs/adr/0003-read-only-enforcement.md) for enforcement details.
 
-- Wrapping or proxying `azure-mcp`. Anything `azure-mcp` already exposes (raw KQL/ARG, quota, advisor, monitor, policy, RBAC, AKS, App Service) is **explicitly out**.
+## Skills (8)
+
+Orchestration skills layer above the server and companion kit:
+
+| Skill | Purpose |
+|-------|---------|
+| `design-review` | Comprehensive Well-Architected review. Pulls current state, runs scorecard, highlights gaps, renders diagram. |
+| `alz-gap-check` | ALZ readiness mini-audit. Maps checklist items to resources found. Reports high-impact gaps. |
+| `ingress-migration-plan` | Kubernetes ingress migration planner. Current state via kubernetes-mcp, plan via orchestration. |
+| `policy-as-code-suggest` | Draft Azure Policy rules from unmet checklist items. Compliance-as-code pattern. |
+| `alz-vendoring` | Refresh ALZ query snapshot from upstream. Vendor management skill (internal). |
+| `fastmcp-bootstrap` | FastMCP new-tool scaffolding. Training skill. |
+| `mcp-runtime-evaluation` | Evaluate runtime choices for new tools. Training skill. |
+| `stride-lite-mcp-readonly` | Threat model for read-only tools. Training skill. |
+
+Each skill links to a `.squad/skills/*/SKILL.md` reference. See [docs/skills](docs/skills) for user-facing catalogs.
+
+## What's in scope and out of scope
+
+**In scope:**
+- Native MCP tools for ALZ checklist queries, scoring, and pricing lookup.
+- Read-only architect orchestration skills (design review, gap analysis, migration planning, policy drafting).
+- Curated companion kit via `mcp-config.json`.
+- DefaultAzureCredential auth, no mutation tools.
+
+**Out of scope:**
+- Wrapping or proxying `azure-mcp`. Anything `azure-mcp` already exposes (raw KQL, Advisor, Monitor, Policy, RBAC, AKS, App Service) is **explicitly out**.
 - Mutation tools (create/update/delete on Azure). Read-only stays read-only.
-- Hosted multi-tenant deployment. Local-first.
+- Hosted multi-tenant deployment. Local-first only.
 
-## Companion servers (recommended, not bundled)
+## Architecture
 
-| Server | Why an architect wants it |
-|--------|---------------------------|
-| `azure-mcp` (Microsoft) | ARG, Advisor, Monitor, Policy, RBAC, AKS, AppService, ... |
-| `microsoft-learn-mcp` | Grounded MS docs lookup |
-| `github` MCP | Repo, issue, PR access for IaC reviews |
-| `mermaid-mcp` | Render architecture diagrams inline |
-| `drawio-mcp` | Visio-replacement diagrams, exportable |
-| `kubernetes-mcp` | Live cluster inspection during design reviews |
-| `terraform-mcp` (HashiCorp) | Plan, validate, registry lookup |
-
-The default `mcp-config.json` shipped with this repo wires these up. Edit before use.
+```mermaid
+graph TB
+    Client["MCP Client<br/>(Copilot CLI / Claude Desktop / Cursor / VS Code)"]
+    
+    subgraph This["mcp-server-azure-architect (5 tools)"]
+        HC["health_check"]
+        ALZ_QUERY["alz_query_by_id"]
+        PRICE_LOOKUP["pricing_lookup_sku"]
+        PRICE_COMPARE["pricing_compare_skus"]
+        SCORECARD["alz_scorecard"]
+    end
+    
+    subgraph Data["Data Sources"]
+        SNAPSHOT["vendored ALZ snapshot<br/>(data/alz-queries/)"]
+        AZURE["Azure subscription<br/>(via ARG)"]
+        RETAIL_API["prices.azure.com<br/>Retail Prices API"]
+    end
+    
+    subgraph Companions["Companion MCP Servers (peers, not children)"]
+        AZURE_MCP["azure-mcp"]
+        LEARN["microsoft-learn"]
+        GITHUB_MCP["github"]
+        MERMAID["mermaid"]
+        DRAWIO["drawio"]
+        K8S["kubernetes"]
+        TF["terraform"]
+    end
+    
+    subgraph Skills["Orchestration Skills<br/>(design-review, alz-gap-check, etc.)"]
+        SKILL_TEXT["8 architect skills<br/>composed from server + companions"]
+    end
+    
+    Client -->|MCP protocol| This
+    Client -->|MCP protocol| Companions
+    
+    ALZ_QUERY --> SNAPSHOT
+    SCORECARD --> SNAPSHOT
+    SCORECARD --> AZURE
+    PRICE_LOOKUP --> RETAIL_API
+    PRICE_COMPARE --> RETAIL_API
+    
+    Skills -->|call all above| This
+    Skills -->|call all above| Companions
+    
+    style This fill:#e1f5ff
+    style Companions fill:#f3e5f5
+    style Skills fill:#fffde7
+    style Data fill:#f1f8e9
+```
 
 ## Status
 
-Pre-alpha. Backlog tracked as GitHub issues with the `squad` label. Runtime ratified per ADR-001 (Python + FastMCP).
+Pre-alpha. Backlog tracked as GitHub issues with the `squad` label. Runtime, vendoring policy, read-only enforcement, and companion selection ratified via ADRs. See [docs/adr](docs/adr) for decisions.
 
 ## Stack
 
-Python 3.11+ with FastMCP, per [ADR-001](docs/adr/0001-runtime-choice.md). Build via Hatchling, lint with ruff, types with mypy, tests with pytest. Distribution via `uvx mcp-server-azure-architect`.
+Python 3.11+ with FastMCP, per [ADR-001](docs/adr/0001-runtime-choice.md). Build via Hatchling, lint with ruff, types with mypy, tests with pytest. Distribution via `uvx mcp-server-azure-architect` (end users); dev install via `uv pip install -e .`.
 
-Constraints:
+**Note:** Package publication is forthcoming. When v0.1.0 publishes to PyPI, `uvx mcp-server-azure-architect` will be the canonical path. For now, use dev install or the install script (see Quickstart).
 
-- Local-first, single binary or single-process startup. Cold-start budget under 1 second on Python 3.12 (per ADR-001 measurements).
-- Read-only Azure SDK calls only. DefaultAzureCredential exclusively.
+**Constraints:**
+- Local-first, single process. Cold-start under 1 second on Python 3.12 (per ADR-001 measurements).
+- Read-only Azure SDK calls only. DefaultAzureCredential exclusively. See [ADR-003](docs/adr/0003-read-only-enforcement.md).
 - Zero credentials at rest. Token-scrub on any logging.
-- ALZ checklist queries source from the public `martinopedal/alz-checklist-queries` and `martinopedal/alz-graph-queries` repos (vendored snapshot, pinned by upstream commit SHA).
-
-## Squad
-
-Multi-agent dev via [Squad by Brady Gaster](https://github.com/bradygaster/squad). Team in `.squad/team.md`. Routing in `.squad/routing.md`. Open `squad`-labeled issues are the live backlog.
+- ALZ queries from `martinopedal/alz-checklist-queries` and `martinopedal/alz-graph-queries` (vendored snapshot, pinned by commit SHA). See [ADR-002](docs/adr/0002-alz-query-vendoring-policy.md).
+- Companion servers do not proxy `azure-mcp`. See [ADR-004](docs/adr/0004-companion-server-bar.md).
 
 ## Quickstart
 
 ### Install
 
-For end users:
+**Recommended for local development:**
+
+```bash
+python scripts/install_kit.py
+```
+
+This script installs the server, dev dependencies, and companion kit in one step. (Landing in PR #16; use editable install below until then.)
+
+**Editable install (alternative for now):**
+
+```bash
+pip install uv
+uv pip install -e ".[dev]"
+```
+
+**End users (when v0.1.0 publishes):**
 
 ```bash
 uvx mcp-server-azure-architect
 ```
 
-For development (editable install):
-
-```bash
-# Install uv if not already available
-pip install uv
-
-# Install package with dev dependencies
-uv pip install -e ".[dev]"
-```
-
 ### Run
 
-Run the server via stdio transport:
+Start the server via stdio:
 
 ```bash
 mcp-server-azure-architect
@@ -96,17 +167,32 @@ Test with MCP Inspector:
 npx @modelcontextprotocol/inspector mcp-server-azure-architect
 ```
 
+### Configure
+
+Add to your MCP client config (e.g., `~/.config/claude/mcp.json` for Claude Desktop or `~/.cursor/mcp.json` for Cursor):
+
+```json
+{
+  "mcpServers": {
+    "mcp-server-azure-architect": {
+      "command": "uvx",
+      "args": ["mcp-server-azure-architect"]
+    }
+  }
+}
+```
+
+Or use the curated `mcp-config.json` shipped with this repo as a template.
+
 ### Authentication
 
-The server uses Azure `DefaultAzureCredential` for authentication, which supports multiple credential sources in this order:
+The server uses `DefaultAzureCredential` from the Azure SDK. It tries credentials in this order:
 
 1. Environment variables (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`)
 2. Managed Identity (when running on Azure compute)
 3. Azure CLI (`az login`)
 
-All tools are read-only by design. No Azure write operations are exposed.
-
-For more details on the runtime choice, see [docs/adr/0001-runtime-choice.md](docs/adr/0001-runtime-choice.md).
+All tools are read-only. No Azure write operations are exposed.
 
 ## Development
 
@@ -123,20 +209,32 @@ This test validates that:
 - Every tool has a valid JSON Schema for its inputs
 - The health_check tool can be invoked successfully
 
-The smoke test does NOT call Azure, it only exercises the MCP protocol layer.
+The smoke test does NOT call Azure, it only exercises the MCP protocol layer. Typical runtime is around 13 seconds.
 
 ### Run Tests
 
 ```bash
-pytest -v
+python -m pytest -q
 ```
 
 ### Linting and Type Checking
 
 ```bash
-ruff check .
-mypy src
+python -m ruff check .
+python -m mypy src tests scripts
 ```
+
+## Squad and Contributions
+
+Multi-agent dev via [Squad by Brady Gaster](https://github.com/bradygaster/squad). Team roles in [`.squad/team.md`](.squad/team.md). Routing rules in [`.squad/routing.md`](.squad/routing.md). Open `squad`-labeled issues are the live backlog. Non-authors must have at least one reviewer sign-off before merge.
+
+## References and further reading
+
+- **Decision records:** See [`docs/adr/`](docs/adr/) for architecture decisions on runtime choice, ALZ query vendoring, read-only enforcement, and companion selection.
+- **Skills catalog:** See [`docs/skills/`](docs/skills) (under development; interim reference is `.squad/skills/*/SKILL.md`).
+- **Threat model:** See [`SECURITY.md`](SECURITY.md) for read-only threat model and security guidelines.
+- **Vendoring manifest:** See [`data/alz-queries/MANIFEST.md`](data/alz-queries/MANIFEST.md) for ALZ query source attribution and refresh policy.
+- **Contributing:** See [`CONTRIBUTING.md`](CONTRIBUTING.md) for development workflows and code review expectations.
 
 ## License
 


### PR DESCRIPTION
## Summary

Comprehensive README rewrite addressing scope drift (old README claimed 2 tools and 4 skills; main has shipped 5 tools and 8 skills). Adds mermaid architecture diagram, honest distribution path, ADR citations, and skills taxonomy.

## Changes

### Added Sections
1. **Native tools (5)** — detailed table of health_check, alz_query_by_id, pricing_lookup_sku, pricing_compare_skus, alz_scorecard with purpose.
2. **Skills (8)** — detailed table split into user-facing (design-review, alz-gap-check, ingress-migration-plan, policy-as-code-suggest) and training/governance (alz-vendoring, fastmcp-bootstrap, mcp-runtime-evaluation, stride-lite-mcp-readonly).
3. **Architecture** — mermaid diagram showing caller -> MCP client -> server -> (ALZ snapshot + Azure ARG + Retail Prices API) + companions as peers (per ADR-004).
4. **References and further reading** — footer with ADR links, skills catalog (forthcoming), threat model, vendoring manifest, CONTRIBUTING.

### Rewritten Sections
- **Why this exists** — now mentions pricing tools, clarifies gap vs. azure-mcp.
- **What's in scope and out of scope** — honest division of labor, explicit ADR-004 reference (companions are peers, not children).
- **Stack** — forward-looking note on publication path (uvx canonical when v0.1.0 lands on PyPI), honest dev path (install script landing in PR #16, fallback to editable install).
- **Quickstart** — install script first, editable install as fallback.

### Removed Sections
- Old companion servers table (preserved in mcp-config.json and companion ADR, no need to duplicate).
- Vague Squad section (now embedded in footer with routing links).

## Lines of Code
- Original: 114 lines.
- New: 235 lines (mermaid diagram, detailed tables, ADR citations).
- Net: +121 (additions), -25 (removals).

## Validation Gates Passed
- ✓ No em dashes (style compliance).
- ✓ Tool list (5) matches server.py exactly.
- ✓ Skill list (8) matches .squad/skills/ exactly.
- ✓ All ADR links resolve (0001-0004).
- ✓ All team/routing links resolve.
- ✓ Mermaid diagram renders correctly.
- ✓ Distribution path honest (uvx future-tense, dev path current).
- ✓ ADR-004 companion logic reflected (peers, not children).

## Related
- Closes #XX (awaiting issue number assignment).
- Decision artifact: .squad/decisions/inbox/sage-readme-rewrite.md
- History update: .squad/agents/sage/history.md

## Notes for Review
1. Mermaid diagram uses color coding for clarity.
2. Forward-looking references to uvx and scripts/install_kit.py correct as of wave-5 merge train.
3. Pre-alpha status retained per task constraints.
4. All 8 skills documented (4 user-facing + 4 training) to reflect repo reality.
