### PR TITLE
security: add workflow permissions (wave-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Overview
Adds explicit workflow permissions block to comply with security audit wave-2 recommendation (MEDIUM severity, 30d SLA).

## Changes
- Added top-level permissions block: contents: read
- Scope: applies to all jobs (test, inspector-smoke)

## Rationale
GitHub Actions workflows should follow principle of least privilege. This CI workflow only needs read access to repository contents for checkout, testing, and validation steps.

## Audit Context
- Squad: The Wire (security audit wave-2)
- Finding: Missing explicit permissions declaration
- SLA: 30 days (MEDIUM severity)
- Workflow: .github/workflows/ci.yml
