### PR TITLE
perf(server): lazy-import azure.identity for 157ms cold-start reduction

### DIFF
--- a/.squad/agents/forge/history.md
+++ b/.squad/agents/forge/history.md
@@ -147,7 +147,52 @@ Python + FastMCP server runtime fully scaffolded per ADR-001. Key choices:
 
 ## Related Artifacts
 
-- `.squad/decisions/inbox/forge-pr26-audit.md` (this session's audit)
+- `.squad/decisions/inbox/forge-pr26-audit.md` (session 1)
+- `.squad/decisions/inbox/forge-lazy-imports.md` (session 2, wave 7)
+
+---
+
+## Session 2: Lazy Import Refactors (Wave 7, 2026-05-12)
+
+**Task**: Ship lazy-import refactors for #67 (azure.identity) and #68 (httpx).
+
+**Outcome**:
+- **Issue #67 (azure.identity)**: FIXED. Moved import from module top to function-local in `azure_client.get_credential()`. Measured 157ms overall cold-start reduction (azure.identity cost deferred to first credential use).
+- **Issue #68 (httpx)**: NOT FIXABLE (FastMCP-owned). httpx is eagerly imported by FastMCP itself via `mcp.shared._httpx_utils`, not by our code. Documented in `pricing.py` docstring.
+
+**Key findings**:
+1. **TYPE_CHECKING guard**: Used `if TYPE_CHECKING:` at module top to satisfy mypy while deferring runtime import. Pattern keeps type hints working without cold-start penalty.
+2. **FastMCP httpx import is irreducible**: profiling confirmed httpx (213ms) comes from FastMCP, not our pricing module. Our lazy import in `_get_client()` was already correct (PR #46).
+3. **Canary test isolation**: Initial tests used `sys.modules.pop()` which caused test isolation failures. Switched to `subprocess.run()` for clean import environment.
+
+**Measurements**:
+- Before: 2,035,173 µs (2.04s)
+- After: 1,878,198 µs (1.88s)
+- Savings: 156,975 µs (157ms, 7.7% faster)
+
+**Deliverables**:
+- `src/mcp_server_azure_architect/azure_client.py` - lazy azure.identity import
+- `src/mcp_server_azure_architect/pricing.py` - documentation note on httpx FastMCP ownership
+- `tests/test_cold_start.py` - 2 new canary tests (82 tests total, all pass)
+- `docs/perf/lazy-import-results.md` - before/after analysis
+- `.squad/decisions/inbox/forge-lazy-imports.md` - decision artifact
+
+**Validation**: All gates passed (read-only, pytest, ruff, mypy, mcp_smoke).
+
+### Learnings
+
+1. **Lazy imports reduce cold start**: Moving azure.identity to function-local deferred 435ms to first use, yielding 157ms overall server import reduction.
+2. **Measure, don't assume**: Issue #68 suspected our code, but profiling revealed FastMCP ownership.
+3. **TYPE_CHECKING for lazy imports**: Pattern to satisfy mypy while deferring runtime cost.
+4. **Test isolation with subprocess**: For canary tests that need clean sys.modules, use subprocess not sys.modules.pop().
+5. **Document upstream constraints**: When an import is not fixable (FastMCP-owned), document clearly so future maintainers don't waste time.
+
+---
+
+## Related Artifacts
+
+- `.squad/decisions/inbox/forge-pr26-audit.md` (session 1)
+- `.squad/decisions/inbox/forge-lazy-imports.md` (session 2, wave 7)
 - `gh issue 32` (dependency tightening follow-up)
 - `docs/perf/coldstart-investigation.md` (measurement evidence)
 - `docs/adr/0001-runtime-choice.md` (ADR update)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Tool docstring style guide** (`docs/dev/tool-docstring-style.md`). Comprehensive pattern extracted from 5 working MCP tools. Covers required structure (summary, description, Args, Returns, Raises, Examples), parameter conventions (optionality, defaults, Literal types), common pitfalls, and test patterns. Google-style docstrings normalized across the project.
 - Native MCP tool `alz_query_list` for enumerating vendored ALZ checklist queries with optional filters (pillar, source_repo). Returns metadata (checklist_id, pillar, source_repo, citation) for up to 200 queries per call. Pairs with `alz_query_by_id` for discovery-then-fetch workflow. (#51)
+- Cold-start canary test for azure.identity lazy import (regression guard for #67).
+- Cold-start canary test documenting httpx as FastMCP-owned dependency (addresses #68).
 
 ### Changed
 
+- **Performance**: Lazy-imported `azure.identity` in `azure_client.get_credential()` to reduce cold-start overhead by 157ms (7.7% faster). See `docs/perf/lazy-import-results.md` for measurements. (Closes #67)
 - ADR-001 revised baseline expectations: measured cold start is 8.5-9.0 seconds on Python 3.12-3.14 (dominated by irreducible FastMCP framework overhead). See `docs/perf/coldstart-investigation.md` for detailed analysis.
 
 ### Fixed
@@ -24,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `docs/companions/` - Supply chain audit notes for all 7 companion MCP servers in the curated kit
 - `docs/perf/coldstart-investigation.md` - Comprehensive cold-start profiling report with import graph analysis and lazy-import recommendations
+- `docs/perf/lazy-import-results.md` - Before/after measurements and analysis for lazy-import refactors
 - `docs/runbook.md` - Operator runbook for daily operation, authentication, common errors, logging, and maintenance workflows
 - `.squad/identity/now.md` - Cross-session continuity hint with current project focus, recent waves, next priorities, and open issues inventory
 - `docs/perf/importtime-baseline-3.14.log` - Raw Python importtime trace (first 200 lines)

--- a/docs/perf/lazy-import-results.md
+++ b/docs/perf/lazy-import-results.md
@@ -1,0 +1,79 @@
+# Lazy Import Results (Wave 7)
+
+**Date**: 2026-05-12  
+**Issues**: #67 (azure.identity), #68 (httpx)  
+**PR**: TBD
+
+## Summary
+
+Refactored eager imports to lazy (function-local) imports to reduce cold-start overhead. Measured improvement: **157ms** (7.7% faster).
+
+## Measurements
+
+| Metric | Before | After | Savings |
+|---|---:|---:|---:|
+| Total server import | 2,035,173 µs (2.04s) | 1,878,198 µs (1.88s) | **156,975 µs (157ms)** |
+| azure.identity | 435,610 µs (435ms) | *deferred* | 435ms (moved to first credential use) |
+| httpx | 213,839 µs (213ms) | 213,839 µs (213ms) | 0ms (FastMCP-owned, not fixable) |
+
+**Measurement method**: `python -X importtime -c "import mcp_server_azure_architect.server" 2> {before,after}.log` on Python 3.14.0, Windows.
+
+## Changes
+
+### Issue #67: azure.identity lazy import
+
+**Problem**: `azure.identity` was eagerly imported at module top in `src/mcp_server_azure_architect/azure_client.py:5`, adding 435ms to cold start.
+
+**Solution**: Moved the import inside `get_credential()` function, guarded by `if TYPE_CHECKING:` for type hints at module top. The import now happens only when a tool actually requests a credential (e.g., scorecard, ALZ queries).
+
+**Impact**:
+- Server import no longer pulls in azure.identity (verified via sys.modules check).
+- First call to `get_credential()` pays the 435ms cost once.
+- Subsequent calls reuse the cached credential.
+
+**Canary test**: `tests/test_cold_start.py::test_azure_identity_lazy_import_canary` ensures azure.identity is NOT in sys.modules after server import.
+
+### Issue #68: httpx in pricing module
+
+**Problem**: Sage's cold-start investigation found httpx (~213ms) in the import chain, suspected to be from `pricing.py`.
+
+**Investigation**: httpx was already lazy-imported in `pricing._get_client()` (PR #46). The 213ms httpx import is actually pulled in by **FastMCP** itself via `mcp.shared._httpx_utils`, not by our code.
+
+**Solution**: No code change. Added documentation in `pricing.py` docstring noting that httpx is FastMCP-owned and not under our control. Our lazy import in `_get_client()` only defers the cost until the pricing tool is invoked, but FastMCP's own import happens at server startup regardless.
+
+**Impact**:
+- httpx remains in sys.modules after server import (expected and not a bug).
+- This is an upstream dependency, not fixable without changes to FastMCP.
+
+**Canary test**: `tests/test_cold_start.py::test_httpx_fastmcp_owned_note` documents that httpx WILL appear in sys.modules after server import.
+
+## Test coverage
+
+Added 2 new canary tests (both use subprocess for clean import environment):
+
+1. `test_azure_identity_lazy_import_canary` - regression guard for #67
+2. `test_httpx_fastmcp_owned_note` - documents FastMCP ownership for #68
+
+Total tests: **82 passed** (up from 80).
+
+## Validation
+
+All gates passed:
+
+- ✅ `python scripts/check_readonly.py src/` — no mutation methods
+- ✅ `python -m pytest -q` — 82 tests passed
+- ✅ `python -m ruff check .` — clean
+- ✅ `python -m mypy src/ tests/ scripts/` — clean
+- ✅ `python scripts/mcp_smoke.py` — server starts, 5 tools registered
+
+## Future work
+
+- **FastMCP httpx import**: If FastMCP refactors to lazy-import httpx, we would gain the 213ms savings automatically. No action on our side.
+- **Other Azure SDK modules**: Consider similar lazy-import treatment for `azure.mgmt.resourcegraph` if it shows up in future profiles. Currently it is already lazy-loaded in `scorecard._get_resource_graph_client()`.
+
+## References
+
+- [docs/perf/coldstart-investigation.md](./coldstart-investigation.md) - Sage's initial analysis
+- Issue #67: `perf: lazy-import azure.identity to reduce cold start by 945ms`
+- Issue #68: `perf: lazy-import httpx in pricing module to reduce cold start by 1.46s`
+- PR #46: Original httpx lazy-import (Forge, 2026-05-12)

--- a/src/mcp_server_azure_architect/azure_client.py
+++ b/src/mcp_server_azure_architect/azure_client.py
@@ -1,8 +1,12 @@
 """Azure client helpers with lazy credential initialization."""
 
-import re
+from __future__ import annotations
 
-from azure.identity import DefaultAzureCredential
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from azure.identity import DefaultAzureCredential
 
 _credential: DefaultAzureCredential | None = None
 
@@ -11,12 +15,16 @@ def get_credential() -> DefaultAzureCredential:
     """Lazily construct and return a DefaultAzureCredential.
 
     This defers credential initialization until first use to minimize cold start time.
+    The azure.identity import happens inside this function to avoid ~435ms import cost
+    at module load time (perf: issue #67).
 
     Returns:
         Azure DefaultAzureCredential instance.
     """
     global _credential
     if _credential is None:
+        from azure.identity import DefaultAzureCredential
+
         _credential = DefaultAzureCredential()
     return _credential
 

--- a/src/mcp_server_azure_architect/pricing.py
+++ b/src/mcp_server_azure_architect/pricing.py
@@ -12,6 +12,12 @@ Caveats surfaced in tool docstrings:
 - USD default currency. The currencyCode parameter is forwarded to the API.
 - No real-time freshness SLA from Microsoft.
 - Reservation discounts only where Microsoft publishes them in the meter.
+
+Performance note (issue #68): httpx (~213ms import cost) is already lazy-imported in
+_get_client() below. However, httpx is also eagerly imported by FastMCP itself via
+mcp.shared._httpx_utils, so our lazy import only defers the cost until the pricing
+tool is first invoked, not until server startup. The FastMCP import is upstream and
+not under our control.
 """
 
 from __future__ import annotations

--- a/tests/test_cold_start.py
+++ b/tests/test_cold_start.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import subprocess
 import sys
 import time
 import warnings
@@ -38,3 +39,66 @@ def test_server_cold_start_under_threshold() -> None:
         f"Cold start {elapsed_ms:.2f}ms exceeds hard gate {HARD_FAIL_MS:.0f}ms."
     )
 
+
+def test_azure_identity_lazy_import_canary() -> None:
+    """Canary test: azure.identity must not be imported until first credential use.
+
+    This regression guard ensures issue #67 stays fixed. The azure.identity import
+    chain costs ~435ms. Lazy-importing it in azure_client.get_credential() keeps
+    the server import fast.
+
+    Uses subprocess to ensure clean import environment.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "import mcp_server_azure_architect.server; "
+                "print('PASS' if 'azure.identity' not in sys.modules else 'FAIL')"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"Import failed: {result.stderr}"
+    assert "PASS" in result.stdout, (
+        "azure.identity was eagerly imported at server startup. "
+        "It should be lazy-imported in azure_client.get_credential(). "
+        "See issue #67."
+    )
+
+
+def test_httpx_fastmcp_owned_note() -> None:
+    """Document that httpx is FastMCP-owned and not under our control (issue #68).
+
+    httpx (~213ms import) is eagerly imported by FastMCP via mcp.shared._httpx_utils.
+    Our pricing module already lazy-imports httpx in _get_client(), but this only
+    defers the cost until the pricing tool is first invoked, not until server startup.
+
+    This test documents the situation and does not fail. It serves as a note for
+    future maintainers that httpx will appear in sys.modules after server import.
+
+    Uses subprocess to ensure clean import environment.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "import mcp_server_azure_architect.server; "
+                "print('PASS' if 'httpx' in sys.modules else 'FAIL')"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"Import failed: {result.stderr}"
+    assert "PASS" in result.stdout, (
+        "httpx is expected to be imported by FastMCP at server startup. "
+        "See issue #68 for context."
+    )


### PR DESCRIPTION
## Summary

Lazy-import refactors for issues #67 (azure.identity) and #68 (httpx) based on Sage's cold-start investigation (PR #69).

**Measured improvement**: 2.04s -> 1.88s server import (157ms savings, 7.7% faster).

## Changes

### Issue #67: azure.identity (FIXED)

- Moved \zure.identity\ import from module-level to \get_credential()\ function
- Used \if TYPE_CHECKING:\ guard to satisfy mypy while deferring runtime import
- azure.identity (435ms cost) now deferred until first credential use
- Added cold-start canary test (regression guard)

### Issue #68: httpx (NOT FIXABLE)

- Investigation revealed httpx (213ms) is imported by **FastMCP** itself via \mcp.shared._httpx_utils\, not by our code
- Our \pricing._get_client()\ already lazy-imports httpx (PR #46 was correct)
- Added documentation in \pricing.py\ docstring noting FastMCP ownership
- Added canary test documenting expected behavior

## Validation

All gates passed:

- ✅ \python scripts/check_readonly.py src/\ — no mutation methods
- ✅ \python -m pytest -q\ — **82 tests passed** (up from 80)
- ✅ \python -m ruff check .\ — clean
- ✅ \python -m mypy src/ tests/ scripts/\ — clean
- ✅ \python scripts/mcp_smoke.py\ — server starts, 5 tools registered

## Measurements

| Metric | Before | After | Savings |
|---|---:|---:|---:|
| Total server import | 2,035,173 µs (2.04s) | 1,878,198 µs (1.88s) | **156,975 µs (157ms)** |
| azure.identity | 435,610 µs (435ms) | *deferred* | 435ms (moved to first use) |
| httpx | 213,839 µs (213ms) | 213,839 µs (213ms) | 0ms (FastMCP-owned) |

See \docs/perf/lazy-import-results.md\ for full analysis.

## Closes

Closes #67  
Addresses #68 (httpx is upstream FastMCP dependency, not under our control)

## Related

- PR #69 (Sage's cold-start investigation)
- [docs/perf/lazy-import-results.md](docs/perf/lazy-import-results.md)