### PR TITLE
security(server): validate caller scope for subscription_id (#57)

### DIFF
--- a/.squad/agents/forge/history.md
+++ b/.squad/agents/forge/history.md
@@ -410,3 +410,36 @@ Filed `.squad/decisions/inbox/forge-docstring-style-guide.md` documenting:
 - **Workflow path filters can block required checks.** If a required check has a path filter and those paths are not touched in a PR, the check never reports, and the PR is blocked despite passing all checks it ran. The simplest correct fix is to drop the path filter entirely (checks are usually fast enough to run unconditionally).
 - **Pattern extraction from working examples.** Instead of inventing a style guide from scratch, extracting from 5 real, shipped examples ensures the guide is grounded in reality and builds on what is already working. This also provides confidence that the pattern is feasible and tested.
 
+
+---
+
+## 2026-01-12: Subscription Scope Validator (Issue #57, PR #78)
+
+**Context:** Implemented confused-deputy defense for subscription_id parameters (Threat S1).
+
+**Implementation choices:**
+
+1. **Caching strategy:** Used module-level dict[int, set[str]] keyed on id(credential) for subscription list caching. Considered functools.lru_cache but couldn't key on credential instance directly. The dict approach gives explicit control and works well with lazy imports.
+
+2. **Mypy comprehension issue:** Set comprehensions with type guards need explicit type annotation or explicit loop. Changed from {sub.subscription_id for sub in subs if sub.subscription_id is not None} to explicit loop with if sub.subscription_id is not None: sub_ids.add(...) to satisfy mypy's type narrowing.
+
+3. **Test mocking path:** Mock path must target the imported module (e.g., azure.mgmt.subscription.SubscriptionClient) not the importing module (azure_client.SubscriptionClient), since the import happens inside the function at runtime (lazy import pattern).
+
+4. **Test fixture pattern:** Used autouse fixture mock_scope_validation() in test_scorecard.py to mock validate_caller_scope globally, then override in specific tests with mock_scope_validation.return_value = False. Clean pattern for retrofitting existing tests.
+
+5. **Pre-existing test failures:** mcp_smoke.py fails on Python 3.14 due to upstream MCP SDK issue (TaskGroup exception). Not related to changes. All 115 pytest tests pass.
+
+**Learnings:**
+
+- **Lazy imports and testing:** When mocking lazily-imported modules, patch the original module path, not the importer. The import statement executes inside the function boundary.
+- **Per-credential caching:** id(credential) is stable within a session and allows caching keyed on credential identity without requiring the credential to be hashable.
+- **GUID redaction pattern:** subscription_id[:8] + "-****-****-****-************" shows first segment for debugging while redacting the rest.
+
+**Validation gates:**
+- ruff check . - All checks passed
+- mypy src/mcp_server_azure_architect - No issues found
+- pytest - 115 passed, 1 skipped
+- scripts/check_readonly.py - No violations
+- mcp_smoke.py - Pre-existing Python 3.14 incompatibility (not related to changes)
+
+**Outcome:** PR #78 opened, all validation gates passed except pre-existing mcp_smoke.py Python 3.14 issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **SHA-256 integrity verification for vendored ALZ queries** (Closes #63). Mitigates threat T1 (compromised vendored query / KQL injection). Each query file now has a SHA-256 hash recorded in `manifest.json`. CI validates hashes on every build before tests run. Any tampered query file triggers build failure. Hash regeneration is explicit via `python scripts/verify_query_integrity.py --update`. The weekly refresh workflow automatically regenerates hashes after pulling new queries from upstream. See `data/alz-queries/CONTRIBUTING.md` for workflow documentation.
+- **Subscription scope validation** (`validate_caller_scope` in `azure_client.py`) defends against confused-deputy attacks (Threat S1, issue #57). All tools accepting `subscription_id` now validate that the requested subscription is in the caller's authorized scope by querying Azure Resource Manager. Out-of-scope subscription IDs are rejected with `PermissionError`. Validation results are cached per credential to avoid repeated ARM calls. Closes #57.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "mcp>=1.27.0,<2.0.0",
     "azure-identity>=1.23.0,<2.0.0",
     "azure-mgmt-resourcegraph>=8.0.0",
+    "azure-mgmt-subscription>=3.0.0",
     "httpx>=0.27.0,<1.0.0",
 ]
 

--- a/src/mcp_server_azure_architect/azure_client.py
+++ b/src/mcp_server_azure_architect/azure_client.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from azure.identity import DefaultAzureCredential
 
+logger = logging.getLogger(__name__)
+
 _credential: DefaultAzureCredential | None = None
+_authorized_subscriptions: dict[int, set[str]] = {}
 
 
 def get_credential() -> DefaultAzureCredential:
@@ -48,3 +52,73 @@ def token_scrub(text: str) -> str:
     text = re.sub(key_pattern, "[REDACTED_KEY]", text)
 
     return text
+
+
+def scrub_subscription_id(subscription_id: str) -> str:
+    """Redact most of a subscription ID for safe logging.
+
+    Args:
+        subscription_id: Azure subscription ID (GUID format).
+
+    Returns:
+        Redacted subscription ID (e.g., 12345678-****-****-****-************).
+    """
+    if len(subscription_id) < 36:
+        return subscription_id[:8] + "-****-****-****-************"
+    return subscription_id[:8] + "-****-****-****-************"
+
+
+def validate_caller_scope(subscription_id: str, credential: DefaultAzureCredential) -> bool:
+    """Validate that subscription_id is in the caller's authorized scope.
+
+    Queries Azure Resource Manager to enumerate subscriptions accessible by the
+    credential, then checks if the requested subscription_id is in that list.
+    Results are cached per credential instance to avoid repeated ARM calls.
+
+    This defends against confused-deputy attacks where an AI agent is tricked
+    into probing subscriptions outside the caller's scope (Threat S1, issue #57).
+
+    Args:
+        subscription_id: Azure subscription ID to validate.
+        credential: DefaultAzureCredential instance.
+
+    Returns:
+        True if subscription_id is in the caller's scope, False otherwise.
+
+    Raises:
+        Exception: If ARM call to list subscriptions fails.
+    """
+    cred_id = id(credential)
+
+    # Check cache
+    if cred_id not in _authorized_subscriptions:
+        # Lazy import to minimize cold-start overhead
+        from azure.mgmt.subscription import SubscriptionClient
+
+        logger.info("Enumerating authorized subscriptions for scope validation")
+        client = SubscriptionClient(credential=credential)
+
+        try:
+            # List all subscriptions accessible to this credential
+            subs = client.subscriptions.list()
+            sub_ids: set[str] = set()
+            for sub in subs:
+                if sub.subscription_id is not None:
+                    sub_ids.add(sub.subscription_id)
+            _authorized_subscriptions[cred_id] = sub_ids
+            logger.info(f"Cached {len(sub_ids)} authorized subscription(s)")
+        except Exception as e:
+            scrubbed_error = token_scrub(str(e))
+            logger.error(f"Failed to enumerate subscriptions: {scrubbed_error}")
+            raise
+
+    authorized = _authorized_subscriptions[cred_id]
+    is_valid = subscription_id in authorized
+
+    if not is_valid:
+        scrubbed_id = scrub_subscription_id(subscription_id)
+        logger.warning(
+            f"Subscription ID validation failed: {scrubbed_id} is not in caller's scope"
+        )
+
+    return is_valid

--- a/src/mcp_server_azure_architect/scorecard.py
+++ b/src/mcp_server_azure_architect/scorecard.py
@@ -28,7 +28,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from mcp_server_azure_architect.alz_queries import get_query, list_query_ids
-from mcp_server_azure_architect.azure_client import get_credential
+from mcp_server_azure_architect.azure_client import get_credential, validate_caller_scope
 
 if TYPE_CHECKING:
     from azure.mgmt.resourcegraph import ResourceGraphClient
@@ -191,7 +191,16 @@ async def run_scorecard(
 
     Raises:
         ValueError: if explicit checklist_ids exceeds 25.
+        PermissionError: if subscription_id is not in the caller's scope (Threat S1).
     """
+    # Validate that subscription_id is in caller's scope (issue #57, Threat S1)
+    credential = get_credential()
+    if not validate_caller_scope(subscription_id, credential):
+        raise PermissionError(
+            "Subscription ID is not in your scope. "
+            "Ensure you have access to the requested subscription."
+        )
+
     # Determine which checklist IDs to run
     if checklist_ids is not None:
         if len(checklist_ids) > _MAX_QUERIES_PER_CALL:

--- a/src/mcp_server_azure_architect/server.py
+++ b/src/mcp_server_azure_architect/server.py
@@ -144,6 +144,10 @@ async def alz_scorecard(
     Read-only: calls ResourceGraphClient.resources() only. No mutations, no
     Begin*/Create*/Update*/Delete* operations per ADR-003.
 
+    Security: Validates that subscription_id is in the caller's authorized scope
+    by querying Azure Resource Manager (ARM) for accessible subscriptions. Rejects
+    out-of-scope subscription IDs to defend against confused-deputy attacks (issue #57).
+
     Args:
         subscription_id: Azure subscription ID to evaluate.
         pillar: Optional pillar filter (e.g., "checklist", "graph"). If provided,
@@ -158,6 +162,7 @@ async def alz_scorecard(
 
     Raises:
         ValueError: if explicit checklist_ids exceeds 25.
+        PermissionError: if subscription_id is not in caller's scope.
     """
     result = await run_scorecard(
         subscription_id=subscription_id,

--- a/tests/test_azure_client.py
+++ b/tests/test_azure_client.py
@@ -1,0 +1,167 @@
+"""Tests for azure_client helpers including scope validation."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_server_azure_architect.azure_client import (
+    scrub_subscription_id,
+    token_scrub,
+    validate_caller_scope,
+)
+
+
+def test_token_scrub_removes_jwt() -> None:
+    """JWT tokens are redacted."""
+    text = "Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+    scrubbed = token_scrub(text)
+    assert "[REDACTED_TOKEN]" in scrubbed
+    assert "eyJ" not in scrubbed
+
+
+def test_token_scrub_removes_long_base64() -> None:
+    """Long base64-like strings (potential keys) are redacted."""
+    text = "Key: ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=="
+    scrubbed = token_scrub(text)
+    assert "[REDACTED_KEY]" in scrubbed
+    assert "ABCDEFGHIJKLMNOP" not in scrubbed
+
+
+def test_scrub_subscription_id_redacts_most_of_guid() -> None:
+    """Subscription ID is partially redacted for safe logging."""
+    sub_id = "12345678-abcd-ef12-3456-abcdefabcdef"
+    scrubbed = scrub_subscription_id(sub_id)
+    assert scrubbed == "12345678-****-****-****-************"
+
+
+def test_scrub_subscription_id_short_string() -> None:
+    """Short strings are handled gracefully."""
+    scrubbed = scrub_subscription_id("short")
+    assert "****" in scrubbed
+
+
+def test_validate_caller_scope_accepts_valid_subscription() -> None:
+    """Subscription in the authorized list passes validation."""
+    mock_credential = Mock()
+
+    # Mock SubscriptionClient.subscriptions.list()
+    mock_sub1 = Mock()
+    mock_sub1.subscription_id = "valid-sub-1"
+    mock_sub2 = Mock()
+    mock_sub2.subscription_id = "valid-sub-2"
+
+    with patch(
+        "azure.mgmt.subscription.SubscriptionClient"
+    ) as mock_client_class:
+        mock_client = Mock()
+        mock_client.subscriptions.list.return_value = [mock_sub1, mock_sub2]
+        mock_client_class.return_value = mock_client
+
+        # Clear cache to ensure fresh enumeration
+        from mcp_server_azure_architect.azure_client import _authorized_subscriptions
+
+        _authorized_subscriptions.clear()
+
+        result = validate_caller_scope("valid-sub-1", mock_credential)
+        assert result is True
+
+        # Verify subscription list was called
+        mock_client.subscriptions.list.assert_called_once()
+
+
+def test_validate_caller_scope_rejects_invalid_subscription() -> None:
+    """Subscription not in the authorized list fails validation."""
+    mock_credential = Mock()
+
+    mock_sub1 = Mock()
+    mock_sub1.subscription_id = "valid-sub-1"
+
+    with patch(
+        "azure.mgmt.subscription.SubscriptionClient"
+    ) as mock_client_class:
+        mock_client = Mock()
+        mock_client.subscriptions.list.return_value = [mock_sub1]
+        mock_client_class.return_value = mock_client
+
+        from mcp_server_azure_architect.azure_client import _authorized_subscriptions
+
+        _authorized_subscriptions.clear()
+
+        result = validate_caller_scope("invalid-sub-xyz", mock_credential)
+        assert result is False
+
+
+def test_validate_caller_scope_caches_subscription_list() -> None:
+    """Subscription list is cached per credential to avoid repeated ARM calls."""
+    mock_credential = Mock()
+
+    mock_sub1 = Mock()
+    mock_sub1.subscription_id = "valid-sub-1"
+
+    with patch(
+        "azure.mgmt.subscription.SubscriptionClient"
+    ) as mock_client_class:
+        mock_client = Mock()
+        mock_client.subscriptions.list.return_value = [mock_sub1]
+        mock_client_class.return_value = mock_client
+
+        from mcp_server_azure_architect.azure_client import _authorized_subscriptions
+
+        _authorized_subscriptions.clear()
+
+        # First call: should query ARM
+        result1 = validate_caller_scope("valid-sub-1", mock_credential)
+        assert result1 is True
+        assert mock_client.subscriptions.list.call_count == 1
+
+        # Second call with same credential: should use cache
+        result2 = validate_caller_scope("valid-sub-1", mock_credential)
+        assert result2 is True
+        assert mock_client.subscriptions.list.call_count == 1  # Not called again
+
+
+def test_validate_caller_scope_propagates_arm_errors() -> None:
+    """ARM API errors are propagated to the caller."""
+    mock_credential = Mock()
+
+    with patch(
+        "azure.mgmt.subscription.SubscriptionClient"
+    ) as mock_client_class:
+        mock_client = Mock()
+        mock_client.subscriptions.list.side_effect = Exception("ARM API unavailable")
+        mock_client_class.return_value = mock_client
+
+        from mcp_server_azure_architect.azure_client import _authorized_subscriptions
+
+        _authorized_subscriptions.clear()
+
+        with pytest.raises(Exception) as excinfo:
+            validate_caller_scope("any-sub", mock_credential)
+
+        assert "ARM API unavailable" in str(excinfo.value)
+
+
+def test_validate_caller_scope_handles_none_subscription_ids() -> None:
+    """Subscriptions with None ID are handled gracefully."""
+    mock_credential = Mock()
+
+    mock_sub1 = Mock()
+    mock_sub1.subscription_id = "valid-sub-1"
+    mock_sub2 = Mock()
+    mock_sub2.subscription_id = None  # ARM can return subscriptions with no ID
+
+    with patch(
+        "azure.mgmt.subscription.SubscriptionClient"
+    ) as mock_client_class:
+        mock_client = Mock()
+        mock_client.subscriptions.list.return_value = [mock_sub1, mock_sub2]
+        mock_client_class.return_value = mock_client
+
+        from mcp_server_azure_architect.azure_client import _authorized_subscriptions
+
+        _authorized_subscriptions.clear()
+
+        result = validate_caller_scope("valid-sub-1", mock_credential)
+        assert result is True

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -20,6 +20,16 @@ def reset_alz_cache() -> None:
     alz_queries.reset_cache()
 
 
+@pytest.fixture(autouse=True)
+def mock_scope_validation() -> Any:
+    """Mock validate_caller_scope to always return True unless overridden."""
+    with patch(
+        "mcp_server_azure_architect.scorecard.validate_caller_scope"
+    ) as mock_validate:
+        mock_validate.return_value = True
+        yield mock_validate
+
+
 def _mock_arg_response(rows: list[dict[str, Any]]) -> Mock:
     """Build a mock ARG response."""
     mock_response = Mock()
@@ -261,6 +271,34 @@ async def test_scorecard_citation_included() -> None:
         assert result["results"][0]["citation"]
         assert "martinopedal" in result["results"][0]["citation"]
         assert "54f0d8b1-22a3-4c0d-8ce2-58b9e086c93a" in result["results"][0]["citation"]
+
+
+@pytest.mark.asyncio
+async def test_scorecard_rejects_out_of_scope_subscription(
+    mock_scope_validation: Any,
+) -> None:
+    """Scorecard rejects subscription_id not in caller's scope (issue #57)."""
+    mock_scope_validation.return_value = False
+
+    with pytest.raises(PermissionError) as excinfo:
+        await run_scorecard(subscription_id="out-of-scope-sub")
+
+    assert "not in your scope" in str(excinfo.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_scorecard_accepts_in_scope_subscription() -> None:
+    """Scorecard accepts subscription_id in caller's scope."""
+    with patch(
+        "mcp_server_azure_architect.scorecard._get_resource_graph_client"
+    ) as mock_client_factory:
+        mock_client = Mock()
+        mock_client.resources = Mock(return_value=_mock_arg_response([]))
+        mock_client_factory.return_value = mock_client
+
+        result = await run_scorecard(subscription_id="in-scope-sub")
+
+        assert result["subscription_id"] == "in-scope-sub"
 
 
 def test_scorecard_no_azure_sdk_at_module_import() -> None:


### PR DESCRIPTION
## Summary

Implements subscription scope validation to defend against confused-deputy attacks (Threat S1, issue #57).

## Changes

**Core Implementation:**
- zure_client.py: Added alidate_caller_scope() helper that queries Azure Resource Manager to enumerate authorized subscriptions and validates subscription_id parameters
- zure_client.py: Added scrub_subscription_id() for safe logging of subscription GUIDs
- Subscription list is cached per credential instance to avoid repeated ARM calls (performance optimization)

**Integration:**
- scorecard.py: Added scope validation check in un_scorecard() before Resource Graph queries
- server.py: Updated lz_scorecard tool docstring to document security validation
- pyproject.toml: Added zure-mgmt-subscription>=3.0.0 dependency

**Testing:**
- 	ests/test_azure_client.py: Unit tests for scope validation with mocked ARM API responses
- 	ests/test_scorecard.py: Integration tests verifying PermissionError on out-of-scope subscription IDs
- Added autouse fixture to mock scope validation in existing scorecard tests

**Documentation:**
- CHANGELOG.md: Added entry under [Unreleased] ### Security section

## Validation Gates

✅ uff check . - All checks passed
✅ mypy src/mcp_server_azure_architect - No issues found
✅ pytest - 115 passed, 1 skipped in 8.21s
✅ scripts/check_readonly.py - No read-only violations
⚠️ mcp_smoke.py - Pre-existing Python 3.14 incompatibility in MCP SDK (not related to changes)

## Key Design Decisions

1. **Lazy import:** azure.mgmt.subscription imported inside function to preserve cold-start performance
2. **Caching:** Subscription list cached per credential (keyed on id(credential)) to avoid 1-2s ARM call on every tool invocation
3. **Read-only:** Subscription enumeration uses ARM read-only API (subscriptions.list())
4. **Token scrubbing:** Subscription IDs redacted to 12345678-****-****-****-************ in logs

Closes #57