### PR TITLE
security: pin GitHub Actions to SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
       
@@ -49,10 +49,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       


### PR DESCRIPTION
## McNulty DevSecOps Wave-5 Fix

**Context:** Floating action tags (e.g., \ctions/checkout@v6\) allow upstream maintainers to inject malicious code into workflows by updating the tag pointer.

**Changes:**
- \ctions/checkout@v6\ → \@de0fac2e4500dabe0009e67214ff5f5447ce83dd\ (v6)
- \ctions/setup-python@v5\ → \@a26af69be951a213d495a4c3e4e4022e16d87065\ (v5)

**Impact:** Supply-chain hardening. Reduces attack surface by requiring explicit SHA bumps for action updates.

**Note:** Comment preserves human-readable version for reference.