### PR TITLE
docs: fix broken link to threat-model in usage-guide

### DIFF
--- a/docs/install/usage-guide.md
+++ b/docs/install/usage-guide.md
@@ -154,5 +154,5 @@ Adapt the classifications, permitted uses, and contact details to match your org
 
 - **Deployment and Operations:** `docs/install/deployment-guide.md`
 - **Operator Runbook:** `docs/runbook.md`
-- **Threat Model and Security Considerations:** `docs/threat-model.md` (if available)
+- **Threat Model and Security Considerations:** `docs/security/threat-model.md` (if available)
 - **Compliance Guidance:** Contact your organization's Data Office or Compliance team


### PR DESCRIPTION
Fixes broken relative link in usage-guide.md line 157. The link referenced docs/threat-model.md but the correct path is docs/security/threat-model.md after the security documentation reorganization in PR #77.

Closes #85