### PR TITLE
docs: retire quota planner and Advisor surfacing from mission (#91)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-MCP server and Copilot CLI skills bundle for Azure architects. Native tools fill the gap above `azure-mcp` (named ALZ queries, scorecard, quota planner, Advisor surfacing). Skills orchestrate the kit. Curated `mcp-config.json` wires companion servers.
+MCP server and Copilot CLI skills bundle for Azure architects. Native tools fill the gap above `azure-mcp` with named ALZ checklist queries and ALZ Corp scorecard composition (pricing retail SKU lookups). Quota planning and Advisor surfacing are covered by `microsoft/mcp` namespaces per ADR-004. Architect-specific Copilot skills orchestrate the kit. Curated `mcp-config.json` wires read-only companion servers.
 
 ## Style
 

--- a/.squad/identity/now.md
+++ b/.squad/identity/now.md
@@ -17,7 +17,7 @@ MCP server + Copilot CLI skills bundle for Azure architects, v0.1.0 RC. Ships 6 
 
 1. **First PyPI publish (v0.1.0).** Cut tag, release workflow runs, package lands on PyPI. Blocks external adoption.
 2. **Perf work (Forge):** Issues #67, #68. Lazy-import azure.identity and httpx to reduce cold start by 2.4s total. Re-measure.
-3. **v0.2 planning.** New tools (quota planner, advisor surfacing per AGENTS.md mission scope). Threat model resolution for issues #57-63. Skill expansion.
+3. **v0.2 planning.** Vendored catalogue expansion (graph bulk vendor for 132 items per Atlas roadmap). Threat model resolution for issues #57-63. Skill expansion (alz-gap-check, alz-quota-planner-compose as skill not tool).
 
 ## Open Issues
 


### PR DESCRIPTION
This PR retires quota planner and Advisor surfacing from the project mission statement in accordance with ADR-004.

Per Lead synthesis section 2.E, both quota planning and Advisor surfacing are now natively covered by microsoft/mcp namespaces (folded from archived Azure/azure-mcp on 2026-02-06). These capabilities belong in the skills layer as orchestration patterns, not in the native server scope.

Changes:
- Updated .github/copilot-instructions.md mission line to remove quota planner and Advisor surfacing, add reference to microsoft/mcp per ADR-004
- Updated .squad/identity/now.md item 3 to reflect v0.2 north star as vendored catalogue expansion and skill composition

Closes #91