### PR TITLE
chore(ci): SHA-pin all actions in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       tag: ${{ steps.get-tag.outputs.tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Extract tag
         id: get-tag
@@ -49,10 +49,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
       
@@ -77,10 +77,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
 
@@ -91,7 +91,7 @@ jobs:
         run: python -m build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: dist
           path: dist/*
@@ -108,13 +108,13 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d  # v1.14.0
 
   create-release:
     name: Create GitHub Release
@@ -124,7 +124,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Extract changelog for this version
         id: changelog
@@ -136,7 +136,7 @@ jobs:
           sed -i -e :a -e '/^\s*$/d;N;ba' release-notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           body_path: release-notes.md
           draft: false


### PR DESCRIPTION
Closes #86

Completes supply-chain SHA pinning started in PR #84. All actions in release.yml are now pinned to immutable commit SHAs, mitigating T-T1 (supply-chain integrity) threat.

## Changes

Pinned 8 action references across 5 jobs:

- **actions/checkout@v6** → \de0fac2e4500dabe0009e67214ff5f5447ce83dd\ (4 instances)
- **actions/setup-python@v5** → \26af69be951a213d495a4c3e4e4022e16d87065\ (2 instances)
- **actions/upload-artifact@v4** → \a165f8d65b6e75b540449e92b4886f43607fa02\
- **actions/download-artifact@v4** → \d3f86a106a0bac45b974a628896c90dbdf5c8093\
- **pypa/gh-action-pypi-publish@release/v1** → \6733eb7d741f0b11ec6a39b58540dab7590f9b7d\ (v1.14.0) ⚠️ **branch ref replaced**
- **softprops/action-gh-release@v2** → \3bb12739c298aeb8a4eeaf626c5b8d85266b0e65\

## Risk reduction

The pypa/gh-action-pypi-publish change is highest impact: replaced a mutable branch reference (release/v1) with a pinned stable release (v1.14.0 SHA). This action sits on the PyPI publish path, making it a critical supply-chain checkpoint.

## Validation

All pins match the latest stable release tags for each action. Version comments inline for future maintainer reference.