### PR TITLE
docs(companions): repoint azure-mcp to microsoft/mcp, add --read-only

### DIFF
--- a/.copilot/mcp-config.json
+++ b/.copilot/mcp-config.json
@@ -6,7 +6,7 @@
       "_purpose": "Official Microsoft Azure MCP. Source of truth for ARG, Quota, Advisor, Monitor, Policy, RBAC, AKS, AppService.",
       "_disabled_instructions": "Set disabled:true to opt out of this server.",
       "command": "npx",
-      "args": ["-y", "@azure/mcp@2.0.1"]
+      "args": ["-y", "@azure/mcp@2.0.1", "server", "start", "--read-only"]
     },
     "microsoft-learn": {
       "_purpose": "Grounded Microsoft Learn doc lookup. Reduces architect hallucination. No self-host needed; uses hosted endpoint.",

--- a/docs/adr/0004-companion-server-bar.md
+++ b/docs/adr/0004-companion-server-bar.md
@@ -4,6 +4,14 @@
 
 Accepted (2026-05-12, Burke)
 
+## Addendum: Azure MCP Server Archive and Namespace Reorganization (2026-05-15)
+
+On 2026-02-06, Microsoft archived `Azure/azure-mcp` and consolidated all Azure MCP development into the unified `microsoft/mcp` monorepo under `servers/Azure.Mcp.Server`. The new canonical location is [microsoft/mcp/servers/Azure.Mcp.Server](https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server). The package name remains `@azure/mcp` on npm, but the repository structure and installation commands have changed. The server now exposes `server start` subcommand and supports `--read-only`, `--mode`, and `--namespace` flags for fine-grained control.
+
+Per issue #92 (Lead synthesis 2026-05-15, Bug 2.D), all documentation in this repository has been updated to reference the new canonical location and recommend the `--read-only` flag by default in `.copilot/mcp-config.json`.
+
+Note: The AKS-MCP mutation hazard identified by Sage (rec #8, finding B.3) is documented separately in `docs/companions/kubernetes.md` per issue #101 (not in scope for this addendum).
+
 ## Context
 
 The mcp-server-azure-architect project ships a curated `mcp-config.json` with a set of companion MCP servers. These companions are not bundled with the server itself; instead, they are recommended via configuration and documentation, following the "complement, don't wrap" principle stated in AGENTS.md.

--- a/docs/companions/azure-mcp.md
+++ b/docs/companions/azure-mcp.md
@@ -6,7 +6,7 @@ Exposes official Microsoft Azure REST APIs via the Model Context Protocol. Cover
 
 ## Source
 
-Repository: [microsoft/mcp](https://github.com/microsoft/azure-mcp)  
+Repository: [microsoft/mcp](https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server) (moved from Azure/azure-mcp on 2026-02-06, now archived)  
 Maintainer: Microsoft (official product)
 
 ## Distribution
@@ -21,8 +21,25 @@ Or installed on demand via npx in `.copilot/mcp-config.json`:
 
 ```
 "command": "npx",
-"args": ["-y", "@azure/mcp@2.0.1"]
+"args": ["-y", "@azure/mcp@2.0.1", "server", "start", "--read-only"]
 ```
+
+## Recommended Client Flags
+
+The Azure MCP Server supports several configuration flags that control tool surface and read-only posture:
+
+- `--read-only`: Enables read-only mode. All tools that could potentially mutate Azure resources are disabled. **Recommended for all architect workflows.** This flag is included in the curated `.copilot/mcp-config.json`.
+- `--mode namespace`: Returns only top-level namespace tools (e.g., `azure_arg`, `azure_advisor`) instead of all 40+ granular service tools. Reduces context cost in MCP clients with limited context windows. Use when you need compact tool lists.
+- `--namespace <name>`: Whitelist specific namespaces to load (e.g., `--namespace arg --namespace advisor`). Combine with `--mode namespace` for fine-grained control. Use when you know which Azure services you need and want to minimize noise.
+
+Example config with namespace filtering:
+
+```
+"command": "npx",
+"args": ["-y", "@azure/mcp@2.0.1", "server", "start", "--read-only", "--mode", "namespace", "--namespace", "arg", "--namespace", "advisor"]
+```
+
+For full flag documentation, see [Azure MCP Server README](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/README.md).
 
 ## Auth Model
 
@@ -90,7 +107,9 @@ If azure-mcp is uninstalled:
 
 ## References
 
-- [microsoft/azure-mcp](https://github.com/microsoft/azure-mcp)
+- [microsoft/mcp Azure MCP Server](https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server)
+- [Azure MCP Server README](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/README.md)
 - [npm registry @azure/mcp](https://www.npmjs.com/package/@azure/mcp)
-- `.copilot/mcp-config.json` (pinned version)
+- [Azure/azure-mcp (archived 2026-02-06)](https://github.com/Azure/azure-mcp)
+- `.copilot/mcp-config.json` (pinned version with --read-only)
 - `docs/install/` (per-client setup)


### PR DESCRIPTION
Closes #92

Microsoft archived `Azure/azure-mcp` on 2026-02-06 and moved development to `microsoft/mcp/servers/Azure.Mcp.Server`. This PR updates all documentation to reference the new canonical location and adds the `--read-only` flag by default in `.copilot/mcp-config.json`.

## Changes

- **docs/companions/azure-mcp.md**: Updated repository links, added Recommended Client Flags section documenting `--read-only`, `--mode namespace`, and `--namespace` configuration options.
- **.copilot/mcp-config.json**: Added `--read-only` flag to azure-mcp server args array.
- **docs/adr/0004-companion-server-bar.md**: Added addendum section noting the archive date and repository consolidation.

## Context

Per Lead synthesis 2026-05-15 section 1 (Bug 2.D) and Sage research finding B.2. The `--read-only` flag ensures Azure MCP server disables all mutation tools, aligning with project read-only posture per ADR-003.

## Validation

- All azure-mcp references updated to new microsoft/mcp location
- --read-only flag documented and configured by default
- Only docs files modified (azure-mcp.md, mcp-config.json, ADR-004)
- Conventional commit format with Co-authored-by trailer
