### PR TITLE
docs(companions): document AKS-MCP mutation hazard (#101)

### DIFF
--- a/.squad/agents/burke/history.md
+++ b/.squad/agents/burke/history.md
@@ -69,3 +69,32 @@ Delivered cross-platform kit installer (`scripts/install_kit.py`) that automates
 **Stdlib-only Python scripts age better than scripted installers with dependencies.** Using only Python stdlib (no pip installs needed) means the installer runs anywhere Python 3.11+ is installed, with zero setup. No version conflicts, no `pip install installer-deps` step. For v0.1 tools where we're still learning user needs, stdlib-only reduces friction and maintenance burden.
 
 **Dry-run mode is essential for config-modifying tools.** Architects want to preview changes before committing, especially when merging into existing configs. `--dry-run` flag (prints merged JSON to stdout, touches no files) provides confidence and aids debugging. Standard pattern for infra tools (Terraform plan, Ansible check mode).
+
+## Session 4: Azure MCP Repository Move and Read-Only Flag (Issue #92, PR #108, 2026-05-15)
+
+Fixed live correctness defect: Microsoft archived `Azure/azure-mcp` on 2026-02-06 and consolidated development into `microsoft/mcp/servers/Azure.Mcp.Server`. Updated all docs to reference new canonical location. Added `--read-only` flag by default to `.copilot/mcp-config.json`, plus documented `--mode namespace` and `--namespace` whitelisting knobs for context-cost optimization.
+
+Three files changed: `docs/companions/azure-mcp.md` (new "Recommended Client Flags" section with usage examples), `.copilot/mcp-config.json` (`--read-only` added to azure-mcp args), `docs/adr/0004-companion-server-bar.md` (addendum noting archive date and repository move). PR #108 created on branch `burke/92-azure-mcp-repoint-v2`. Per Lead synthesis 2026-05-15 section 1 (Bug 2.D) and Sage research finding B.2.
+
+## Session 5: AKS-MCP Mutation Hazard Documentation (Issue #101, 2026-05-XX)
+
+Closed issue #101 by documenting the AKS-MCP mutation hazard as a worked example of why Criterion 6 (Read-Only by Design or Config) is essential for companion selection.
+
+**Changes:**
+1. **docs/companions/kubernetes.md**: Added prominent ⚠️ "Hazard: Mutation-Capable Alternatives (AKS-MCP)" section explaining why Azure/aks-mcp is dangerous (arbitrary `call_az`/`call_kubectl` tools, configurable `--access-level` flag), why we deliberately chose the narrower `kubernetes-mcp-server` instead (read-only by design), and detailed mitigation steps if users choose to wire AKS-MCP anyway (explicit `--access-level readonly` flag + per-tool gating in MCP client).
+2. **docs/companions/azure-mcp.md**: Added "Related Companions and Hazards" section with cross-link to the AKS-MCP hazard section, directing readers away from AKS-MCP and explaining our read-only choice.
+3. **docs/adr/0004-companion-server-bar.md**: Added new addendum "Criterion 6 Worked Example: AKS-MCP Mutation Hazard" explaining that AKS-MCP is a real-world example of why read-only-by-default matters when wiring companion servers into AI-driven tools that may invoke tools without explicit confirmation.
+
+**Validation:**
+- Relative markdown links verified (cross-links use correct paths: `kubernetes.md#anchor` from azure-mcp.md, `../companions/kubernetes.md#anchor` from ADR-0004).
+- No Python code blocks in changes (all documentation).
+- Tone: factual, not alarmist. Hazard is real but mitigation is straightforward.
+
+**Acceptance Criteria Met:**
+1. ✅ Located kubernetes/AKS companion doc at `docs/companions/kubernetes.md`.
+2. ✅ Added prominent ⚠️ hazard section near top with specific tool names (`call_az`, `call_kubectl`), ADR-003 citation, and detailed mitigation steps.
+3. ✅ Added smaller note in ADR-0004 as worked example of Criterion 6 importance with cross-link.
+4. ✅ Cross-linked from azure-mcp.md "Related Companions" section.
+5. ✅ Validated markdown links (relative paths verified).
+
+PR created on branch `burke/101-aks-mcp-hazard`.

--- a/docs/adr/0004-companion-server-bar.md
+++ b/docs/adr/0004-companion-server-bar.md
@@ -12,6 +12,16 @@ Per issue #92 (Lead synthesis 2026-05-15, Bug 2.D), all documentation in this re
 
 Note: The AKS-MCP mutation hazard identified by Sage (rec #8, finding B.3) is documented separately in `docs/companions/kubernetes.md` per issue #101 (not in scope for this addendum).
 
+## Addendum: Criterion 6 Worked Example: AKS-MCP Mutation Hazard (2026-05-XX)
+
+Issue #101 documents the [AKS-MCP mutation hazard](../companions/kubernetes.md#-hazard-mutation-capable-alternatives-aks-mcp) as a worked example of why Criterion 6 (Read-Only by Design or Config) is essential for companion server selection.
+
+**Background:** Azure/aks-mcp is an officially Microsoft-maintained MCP server for Kubernetes/AKS integration. It is mutation-capable by default, exposing `call_az` and `call_kubectl` tools that accept arbitrary CLI command strings. These tools can create, update, or delete Azure resources and Kubernetes objects depending on the input and caller's credentials.
+
+**Why Criterion 6 Matters:** This project's read-only posture (AGENTS.md, ADR-003) is non-negotiable. When wiring companion servers into a Copilot CLI that may invoke tools without user confirmation, mutation-capable tools pose a serious risk. AKS-MCP's default configuration violates Criterion 6 and is therefore excluded from the curated companion kit, even though it meets other criteria (stable upstream, signed releases, narrow scope, maintenance signal).
+
+**Mitigation:** This project includes `kubernetes-mcp-server` instead, which is read-only by design (kubectl inspection only, no CLI execution). Users who understand the risks and want AKS-MCP can wire it into their personal `mcp-config.json` with `--access-level readonly` and per-tool gating in their MCP client, but this is explicitly not recommended and deviates from the project's read-only default.
+
 ## Context
 
 The mcp-server-azure-architect project ships a curated `mcp-config.json` with a set of companion MCP servers. These companions are not bundled with the server itself; instead, they are recommended via configuration and documentation, following the "complement, don't wrap" principle stated in AGENTS.md.

--- a/docs/companions/azure-mcp.md
+++ b/docs/companions/azure-mcp.md
@@ -105,6 +105,12 @@ If azure-mcp is uninstalled:
 
 **Risk:** High. Core to the kit.
 
+## Related Companions and Hazards
+
+### Azure Kubernetes Service (AKS) Workload Integration
+
+For visibility into Kubernetes workloads running on AKS clusters, this kit includes `kubernetes-mcp-server` (read-only kubectl inspection). If you are evaluating other Kubernetes integration tools, be aware that [Azure/aks-mcp](https://github.com/Azure/aks-mcp) is mutation-capable by default and is **not recommended** for use with this project. See the [⚠️ Hazard section in kubernetes.md](kubernetes.md#-hazard-mutation-capable-alternatives-aks-mcp) for details and why we chose the narrower read-only alternative.
+
 ## References
 
 - [microsoft/mcp Azure MCP Server](https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server)

--- a/docs/companions/kubernetes.md
+++ b/docs/companions/kubernetes.md
@@ -9,6 +9,52 @@ Provides kubectl-based inspection of live Kubernetes clusters. Architects use th
 Repository: [kubernetes-mcp-server](https://github.com/mkdocs/kubernetes-mcp-server) (unverified; search results suggest community origin)  
 Maintainer: community-maintained
 
+## ⚠️ Hazard: Mutation-Capable Alternatives (AKS-MCP)
+
+Users exploring Kubernetes integration tools may discover [Azure/aks-mcp](https://github.com/Azure/aks-mcp), another community-owned Kubernetes MCP server specifically designed for AKS clusters. **AKS-MCP exposes mutation-capable tools and is incompatible with this project's read-only posture.**
+
+### Why AKS-MCP is Not Included
+
+Azure/aks-mcp provides two problematic tool categories:
+
+1. **Arbitrary CLI execution:** `call_az` and `call_kubectl` tools that accept arbitrary Azure CLI and kubectl command strings. These bypass intent analysis and enable any operation (create, delete, update, exec) depending on the CLI input and the caller's Azure credentials.
+
+2. **Configurable access level:** `--access-level` flag toggles between `readonly` and `readwrite` mode. Even the "readonly" mode can trigger read operations that return sensitive data (e.g., `kubectl exec` pod commands). The "readwrite" mode explicitly enables mutation operations.
+
+### This Project's Choice
+
+This project deliberately includes `kubernetes-mcp-server` (kubectl inspection only) instead of AKS-MCP because:
+
+- **Read-only by design:** No CLI execution, no mutations, no access level toggles. Inspection only (list pods, nodes, services; get resource YAML).
+- **Principle alignment:** ADR-003 and AGENTS.md prohibit mutation tools. "No mutation tools, ever."
+- **Safe for architects:** Architects can inspect live cluster state during design reviews without risk of accidental changes.
+
+### If You Wire AKS-MCP Instead
+
+If you choose to use AKS-MCP in your `mcp-config.json`, you must:
+
+1. **Explicitly set `--access-level readonly`** in the server args to disable write capability.
+2. **Ensure your MCP client supports per-tool gating.** Some clients (Copilot CLI, Claude Desktop) allow you to explicitly allowlist or denylist tools before invoking them. Use this feature to disable `call_az` and `call_kubectl` entirely.
+3. **Review the full tool list** in [Azure/aks-mcp README](https://github.com/Azure/aks-mcp#tools) and understand which tools are available in your access level.
+4. **Document your choice** in your team's MCP configuration docs, noting the deviation from this project's read-only default.
+
+### Example: Wiring AKS-MCP with Safety Guards
+
+If your team has audited AKS-MCP and decided to use it (against this project's recommendation), here is a cautious config:
+
+```json
+{
+  "tools": {
+    "aks-mcp": {
+      "command": "npx",
+      "args": ["-y", "@azure/aks-mcp@latest", "--access-level", "readonly"]
+    }
+  }
+}
+```
+
+**Important note:** Even with `--readonly`, the tool is NOT safe by default. MCP clients must enforce per-tool gating to disable `call_az` and `call_kubectl`. Check your client's documentation.
+
 ## Distribution
 
 Installed via npm:


### PR DESCRIPTION
## Summary
Closes #101 by documenting why AKS-MCP (Azure/aks-mcp) is unsuitable for this project and documenting the hazard for users considering it.

## Changes
- **docs/companions/kubernetes.md**: Added prominent ⚠️ hazard section (44 lines) explaining AKS-MCP mutation surface (call_az, call_kubectl tools with arbitrary CLI strings), why we chose read-only kubernetes-mcp-server instead, and detailed mitigation steps for teams that choose AKS-MCP anyway (--access-level readonly flag + per-tool gating in MCP client)
- **docs/companions/azure-mcp.md**: Added 'Related Companions and Hazards' section with cross-link to kubernetes.md hazard section and explanation of our read-only choice
- **docs/adr/0004-companion-server-bar.md**: Added new addendum 'Criterion 6 Worked Example: AKS-MCP Mutation Hazard' explaining why read-only-by-design matters for companion selection when wiring into AI-driven tools
- **.squad/agents/burke/history.md**: Session 5 entry documenting delivery

## Validation
- Relative markdown links verified and validated
- Hazard documentation cites ADR-0003 (read-only enforcement), AGENTS.md charter
- Tone: factual, not alarmist; mitigation guidance is straightforward
- Per Sage research finding B.3 (documented in inbox/sage-research-roadmap.md)