### PR TITLE
chore(alz): bump graph pin to 448998d01000e7f863d3c1f8876787fd2234a77b

### DIFF
--- a/data/alz-queries/MANIFEST.md
+++ b/data/alz-queries/MANIFEST.md
@@ -2,7 +2,7 @@
 
 Refreshed automatically; see .github/workflows/refresh-alz-snapshot.yml
 
-Vendored at: 2026-04-22T12:35:39Z
+Vendored at: 2026-05-12T21:52:10Z
 
 This snapshot is pinned to commit SHAs. No `main` or `latest` references are used for source content.
 
@@ -19,9 +19,9 @@ This snapshot is pinned to commit SHAs. No `main` or `latest` references are use
 
 ### martinopedal/alz-graph-queries
 
-- commit_sha: `8a3fddabcbf272a19a627770a0d33de5f4ace8ee`
-- ref: `refs/tags/v1.1.0`
-- vendored_at: `2026-04-22T12:35:39Z`
+- commit_sha: `448998d01000e7f863d3c1f8876787fd2234a77b`
+- ref: `commit:448998d01000e7f863d3c1f8876787fd2234a77b`
+- vendored_at: `2026-05-12T21:52:10Z`
 - source_file: `queries/alz_additional_queries.json`
 - checklist_ids: `e8aa1e41-870d-4968-94c6-77be14f510ac, 667313b4-f566-44b5-b984-a859c773e7d2`
 - file_count: `2`

--- a/data/alz-queries/manifest.json
+++ b/data/alz-queries/manifest.json
@@ -24,9 +24,9 @@
     },
     {
       "repo": "martinopedal/alz-graph-queries",
-      "commit_sha": "8a3fddabcbf272a19a627770a0d33de5f4ace8ee",
-      "ref": "refs/tags/v1.1.0",
-      "vendored_at": "2026-04-22T12:35:39Z",
+      "commit_sha": "448998d01000e7f863d3c1f8876787fd2234a77b",
+      "ref": "commit:448998d01000e7f863d3c1f8876787fd2234a77b",
+      "vendored_at": "2026-05-12T21:52:10Z",
       "subset": {
         "source_file": "queries/alz_additional_queries.json",
         "checklist_ids": [


### PR DESCRIPTION
Closes #90

## Summary

Bump martinopedal/alz-graph-queries pin from v1.1.0 (SHA: 8a3fddab...) to upstream HEAD (SHA: 448998d0...).

## Changes

- Updated `data/alz-queries/manifest.json`: sources[1] (graph-queries entry) commit_sha and vendored_at timestamp
- Updated `data/alz-queries/MANIFEST.md`: corresponding timestamp and source metadata

## Verification

- [x] Both vendored query IDs present in upstream alz_additional_queries.json:
  - e8aa1e41-870d-4968-94c6-77be14f510ac
  - 667313b4-f566-44b5-b984-a859c773e7d2
- [x] No KQL content delta detected for either query
- [x] Graph query integrity check passed (sha256 hashes unchanged)
- [x] Ruff format check passed (no new violations)

## Notes

- ref format updated from `refs/tags/v1.1.0` to `commit:448998d01000e7f863d3c1f8876787fd2234a77b` (explicit commit reference)
- Pre-existing mypy and pytest failures in test_scorecard.py are unrelated to this change (no Python code modified)
