### PR TITLE
feat(server): populate MCP tool annotations on all 7 native tools (#97)

### DIFF
--- a/src/mcp_server_azure_architect/server.py
+++ b/src/mcp_server_azure_architect/server.py
@@ -3,6 +3,7 @@
 from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from mcp_server_azure_architect import __version__
 from mcp_server_azure_architect.alz_queries import get_query, list_queries
@@ -24,7 +25,15 @@ from mcp_server_azure_architect.scorecard import run_scorecard
 mcp = FastMCP("azure-architect")
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Server: health check",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    )
+)
 @audit_log_tool
 def health_check() -> dict[str, str]:
     """Check server health and version.
@@ -38,7 +47,15 @@ def health_check() -> dict[str, str]:
     }
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="ALZ: get query by checklist ID",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+)
 @audit_log_tool
 def alz_query_by_id(checklist_id: str) -> dict[str, str]:
     """Look up a vendored Azure Landing Zone (ALZ) checklist query by ID.
@@ -72,7 +89,15 @@ def alz_query_by_id(checklist_id: str) -> dict[str, str]:
     return {key: str(value) for key, value in record.items()}
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Azure Pricing: look up SKU retail price",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+)
 @audit_log_tool
 def pricing_lookup_sku(
     sku: str,
@@ -89,7 +114,15 @@ def pricing_lookup_sku(
     return _pricing_lookup_sku(sku=sku, region=region, term=term, currency=currency)
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Azure Pricing: compare multiple SKUs",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+)
 @audit_log_tool
 def pricing_compare_skus(
     skus: list[str],
@@ -106,7 +139,15 @@ def pricing_compare_skus(
     return _pricing_compare_skus(skus=skus, region=region, term=term, currency=currency)
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Azure Pricing: estimate workload cost",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+)
 @audit_log_tool
 def pricing_estimate_workload(spec: dict[str, Any]) -> dict[str, Any]:
     """Estimate monthly cost for a structured workload specification.
@@ -121,7 +162,15 @@ def pricing_estimate_workload(spec: dict[str, Any]) -> dict[str, Any]:
     return _pricing_estimate_workload(spec=workload)
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="ALZ: list available queries",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+)
 @audit_log_tool
 def alz_query_list(
     pillar: str | None = None,
@@ -164,7 +213,15 @@ def alz_query_list(
     return result
 
 
-@mcp.tool()
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="ALZ: run scorecard against subscription",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+)
 @audit_log_tool
 async def alz_scorecard(
     subscription_id: str,

--- a/tests/test_server_annotations.py
+++ b/tests/test_server_annotations.py
@@ -1,0 +1,141 @@
+"""Test MCP tool annotations for all registered tools.
+
+Verifies that every tool has proper MCP annotations per issue #97 and
+enforces the read-only invariant from ADR-003.
+"""
+
+from mcp_server_azure_architect.server import mcp
+
+
+def test_all_tools_have_annotations() -> None:
+    """Verify all tools have non-None annotations."""
+    tools = mcp._tool_manager.list_tools()
+
+    assert len(tools) == 7, f"Expected 7 tools, got {len(tools)}"
+
+    for tool in tools:
+        assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
+
+
+def test_all_tools_are_read_only() -> None:
+    """Verify all tools have readOnlyHint=True (ADR-003 enforcement)."""
+    tools = mcp._tool_manager.list_tools()
+
+    for tool in tools:
+        assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
+        assert tool.annotations.readOnlyHint is True, (
+            f"Tool {tool.name} must have readOnlyHint=True per ADR-003, "
+            f"got {tool.annotations.readOnlyHint}"
+        )
+
+
+def test_all_tools_are_non_destructive() -> None:
+    """Verify all tools have destructiveHint=False (ADR-003 enforcement)."""
+    tools = mcp._tool_manager.list_tools()
+
+    for tool in tools:
+        assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
+        assert tool.annotations.destructiveHint is False, (
+            f"Tool {tool.name} must have destructiveHint=False per ADR-003, "
+            f"got {tool.annotations.destructiveHint}"
+        )
+
+
+def test_all_tools_have_titles() -> None:
+    """Verify all tools have non-empty human-readable titles."""
+    tools = mcp._tool_manager.list_tools()
+
+    for tool in tools:
+        assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
+        assert tool.annotations.title, f"Tool {tool.name} must have a non-empty title"
+        assert len(tool.annotations.title) > 0, f"Tool {tool.name} title is empty"
+
+
+def test_tool_annotation_completeness() -> None:
+    """Verify all annotation fields are populated for every tool."""
+    tools = mcp._tool_manager.list_tools()
+
+    for tool in tools:
+        assert tool.annotations is not None, f"Tool {tool.name} missing annotations"
+
+        # Check all expected fields are not None
+        assert tool.annotations.title is not None, f"Tool {tool.name} missing title"
+        assert (
+            tool.annotations.readOnlyHint is not None
+        ), f"Tool {tool.name} missing readOnlyHint"
+        assert (
+            tool.annotations.destructiveHint is not None
+        ), f"Tool {tool.name} missing destructiveHint"
+        assert (
+            tool.annotations.idempotentHint is not None
+        ), f"Tool {tool.name} missing idempotentHint"
+        assert (
+            tool.annotations.openWorldHint is not None
+        ), f"Tool {tool.name} missing openWorldHint"
+
+
+def test_expected_tool_titles() -> None:
+    """Verify each tool has the expected human-readable title."""
+    expected_titles = {
+        "health_check": "Server: health check",
+        "alz_query_by_id": "ALZ: get query by checklist ID",
+        "alz_query_list": "ALZ: list available queries",
+        "pricing_lookup_sku": "Azure Pricing: look up SKU retail price",
+        "pricing_compare_skus": "Azure Pricing: compare multiple SKUs",
+        "pricing_estimate_workload": "Azure Pricing: estimate workload cost",
+        "alz_scorecard": "ALZ: run scorecard against subscription",
+    }
+
+    tools = mcp._tool_manager.list_tools()
+    tool_map = {tool.name: tool for tool in tools}
+
+    for tool_name, expected_title in expected_titles.items():
+        assert tool_name in tool_map, f"Tool {tool_name} not registered"
+        tool = tool_map[tool_name]
+        assert tool.annotations is not None, f"Tool {tool_name} missing annotations"
+        assert tool.annotations.title == expected_title, (
+            f"Tool {tool_name} title mismatch: "
+            f"expected '{expected_title}', got '{tool.annotations.title}'"
+        )
+
+
+def test_alz_and_pricing_tools_are_idempotent_and_open_world() -> None:
+    """Verify ALZ and pricing tools have idempotentHint=True, openWorldHint=True."""
+    # ALZ tools read vendored data + call Azure Resource Graph
+    # Pricing tools call Azure Retail Prices API
+    # Both are idempotent and interact with external systems
+    alz_and_pricing_tools = {
+        "alz_query_by_id",
+        "alz_query_list",
+        "alz_scorecard",
+        "pricing_lookup_sku",
+        "pricing_compare_skus",
+        "pricing_estimate_workload",
+    }
+
+    tools = mcp._tool_manager.list_tools()
+
+    for tool in tools:
+        if tool.name in alz_and_pricing_tools:
+            assert tool.annotations is not None
+            assert (
+                tool.annotations.idempotentHint is True
+            ), f"Tool {tool.name} should have idempotentHint=True"
+            assert (
+                tool.annotations.openWorldHint is True
+            ), f"Tool {tool.name} should have openWorldHint=True"
+
+
+def test_health_check_is_closed_world() -> None:
+    """Verify health_check has openWorldHint=False (no external calls)."""
+    tools = mcp._tool_manager.list_tools()
+    health_tool = next((t for t in tools if t.name == "health_check"), None)
+
+    assert health_tool is not None, "health_check tool not found"
+    assert health_tool.annotations is not None
+    assert (
+        health_tool.annotations.openWorldHint is False
+    ), "health_check should have openWorldHint=False (no external calls)"
+    assert (
+        health_tool.annotations.idempotentHint is True
+    ), "health_check should have idempotentHint=True (always returns same result)"


### PR DESCRIPTION
## Summary

Adds MCP tool annotations to all 7 native tools per issue #97. Annotations provide declarative hints for MCP clients to render UX, gate execution, and enforce safety.

Closes #97

## Annotation Matrix

| Tool | Title | readOnly | destructive | idempotent | openWorld |
|------|-------|----------|-------------|------------|-----------|
| health_check | Server: health check | ✓ | ✗ | ✓ | ✗ |
| lz_query_by_id | ALZ: get query by checklist ID | ✓ | ✗ | ✓ | ✓ |
| lz_query_list | ALZ: list available queries | ✓ | ✗ | ✓ | ✓ |
| pricing_lookup_sku | Azure Pricing: look up SKU retail price | ✓ | ✗ | ✓ | ✓ |
| pricing_compare_skus | Azure Pricing: compare multiple SKUs | ✓ | ✗ | ✓ | ✓ |
| pricing_estimate_workload | Azure Pricing: estimate workload cost | ✓ | ✗ | ✓ | ✓ |
| lz_scorecard | ALZ: run scorecard against subscription | ✓ | ✗ | ✓ | ✓ |

## Changes

- **Added ToolAnnotations import** from mcp.types
- **Annotated all 7 @mcp.tool() decorators** with:
  - 	itle: human-readable tool name
  - eadOnlyHint=True: all tools are read-only per ADR-003
  - destructiveHint=False: no destructive operations per ADR-003
  - idempotentHint=True: repeated calls have no additional effect
  - openWorldHint: False for health_check (no external calls), True for ALZ/pricing tools (call Azure APIs)
- **Added comprehensive regression test suite** (	est_server_annotations.py) enforcing:
  - All tools have non-None annotations
  - Read-only invariant (ADR-003)
  - Non-destructive invariant (ADR-003)
  - Complete annotation field population
  - Expected human-readable titles
  - Correct idempotent/openWorld semantics per tool category

## MCP Spec Reference

Per [MCP Specification 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations), tool annotations provide:
- eadOnlyHint: declares tool does not modify environment
- destructiveHint: declares tool may perform destructive updates (only meaningful when readOnly=false)
- idempotentHint: repeated calls with same args have no additional effect
- openWorldHint: interacts with external entities (true) vs closed system (false)

## Validation Gates

✓ **Ruff lint and format clean**
✓ **Mypy type check passes**  
✓ **Pytest unit tests pass** (all 8 new tests + 3 existing server tests)
✓ **MCP Inspector smoke test passes** (tool registration, JSON Schema, health_check invocability)
- Tool count stable at 7
- All tools enumerate with valid JSON Schema
- health_check returns status=ok

## Testing

Eight new regression tests ensure future tools comply:
1. 	est_all_tools_have_annotations - catches missing annotations
2. 	est_all_tools_are_read_only - enforces ADR-003 read-only invariant
3. 	est_all_tools_are_non_destructive - enforces ADR-003 non-destructive invariant
4. 	est_all_tools_have_titles - ensures human-readable titles
5. 	est_tool_annotation_completeness - verifies all fields populated
6. 	est_expected_tool_titles - validates exact title text
7. 	est_alz_and_pricing_tools_are_idempotent_and_open_world - category semantics
8. 	est_health_check_is_closed_world - health_check-specific semantics

## Breaking Changes

None. Tool names, signatures, and behavior unchanged. Annotations are additive metadata.

## Follow-up

This PR does NOT touch the pillar field (issue #94). That remains out of scope.