### PR TITLE
chore(vendoring): license + cadence + third-party notices (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ All tools are read-only by design. No Azure write operations are exposed.
 
 For more details on the runtime choice, see [docs/adr/0001-runtime-choice.md](docs/adr/0001-runtime-choice.md).
 
+## Third-party content
+
+Vendored content licenses are reproduced in [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md).
+
 ## License
 
 MIT.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,72 @@
+# Third-Party Notices
+
+This project includes content vendored from third-party sources. Each source retains its own license. The notices below are reproduced as required by those licenses.
+
+---
+
+## ALZ Checklist Queries (`data/alz-queries/checklist/`)
+
+- **Source:** https://github.com/martinopedal/alz-checklist-queries
+- **License:** MIT
+- **Pinned commit:** `e7641beeda0126cc78825f8b77764c379552f3e1`
+- **Vendored:** `2026-04-22T12:35:39Z`
+
+```
+MIT License
+
+Copyright (c) 2026 martinopedal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## ALZ Graph Queries (`data/alz-queries/graph/`)
+
+- **Source:** https://github.com/martinopedal/alz-graph-queries
+- **License:** MIT
+- **Pinned commit:** `448998d01000e7f863d3c1f8876787fd2234a77b`
+- **Vendored:** `2026-05-12T21:52:10Z`
+
+```
+MIT License
+
+Copyright (c) 2026 martinopedal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+

--- a/data/alz-queries/MANIFEST.md
+++ b/data/alz-queries/MANIFEST.md
@@ -6,6 +6,19 @@ Vendored at: 2026-05-12T21:52:10Z
 
 This snapshot is pinned to commit SHAs. No `main` or `latest` references are used for source content.
 
+## Refresh cadence
+
+Vendored snapshots are refreshed automatically on a **weekly cadence** (Monday 06:00 UTC) via `.github/workflows/refresh-alz-snapshot.yml`. The workflow:
+
+1. Fetches each upstream `commit_sha` listed in `manifest.json`.
+2. Runs `scripts/refresh_alz_snapshot.py` to extract queryable items.
+3. Recomputes SHA-256 integrity hashes per file.
+4. Opens a PR if any content changed.
+
+**Pinning to a snapshot:** Consumers who need reproducible builds should pin to a specific release tag (`pip install mcp-server-azure-architect==X.Y.Z`) rather than tracking `main`. Each release embeds the manifest snapshot active at release time.
+
+**Manual refresh:** Maintainers can trigger an out-of-band refresh by running `python scripts/refresh_alz_snapshot.py` locally and committing the result.
+
 ## Sources
 
 ### martinopedal/alz-checklist-queries

--- a/data/alz-queries/manifest.json
+++ b/data/alz-queries/manifest.json
@@ -5,6 +5,10 @@
       "commit_sha": "e7641beeda0126cc78825f8b77764c379552f3e1",
       "ref": "commit:e7641beeda0126cc78825f8b77764c379552f3e1",
       "vendored_at": "2026-04-22T12:35:39Z",
+      "license": {
+        "spdx": "MIT",
+        "upstream_license_url": "https://github.com/martinopedal/alz-checklist-queries/blob/e7641beeda0126cc78825f8b77764c379552f3e1/LICENSE"
+      },
       "subset": {
         "source_file": "queries/alz_all_queries.json",
         "checklist_ids": [
@@ -27,6 +31,10 @@
       "commit_sha": "448998d01000e7f863d3c1f8876787fd2234a77b",
       "ref": "commit:448998d01000e7f863d3c1f8876787fd2234a77b",
       "vendored_at": "2026-05-12T21:52:10Z",
+      "license": {
+        "spdx": "MIT",
+        "upstream_license_url": "https://github.com/martinopedal/alz-graph-queries/blob/448998d01000e7f863d3c1f8876787fd2234a77b/LICENSE"
+      },
       "subset": {
         "source_file": "queries/alz_additional_queries.json",
         "checklist_ids": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,4 @@ python_functions = ["test_*"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "data/alz-queries" = "mcp_server_azure_architect/_data/alz-queries"
+"THIRD-PARTY-NOTICES.md" = "mcp_server_azure_architect/_THIRD-PARTY-NOTICES.md"


### PR DESCRIPTION
## Summary

Closes #95: Vendoring hygiene improvements per Wave 9 research.

## Changes

### 1. Add license field to manifest.json
- Each source in sources[] now records SPDX identifier and upstream LICENSE URL pinned to commit_sha
- Both upstream sources (alz-checklist-queries, alz-graph-queries) confirmed MIT-licensed
- URL format: https://github.com/{repo}/blob/{commit_sha}/LICENSE

### 2. Document refresh cadence in MANIFEST.md
- Added new 'Refresh cadence' section documenting **weekly Monday 06:00 UTC** refresh cycle
- Verified actual cron schedule in .github/workflows/refresh-alz-snapshot.yml
- Added guidance for consumers on pinning to releases for reproducible builds
- Documented manual refresh option via scripts/refresh_alz_snapshot.py

### 3. Create THIRD-PARTY-NOTICES.md
- New file at repo root reproducing full LICENSE text for each vendored source
- Required by MIT license attribution requirements
- Pinned commit and vendored_at timestamp for each source
- Mirrors manifest.json metadata for traceability

### 4. Reference NOTICES from README and pyproject.toml
- README.md: added 'Third-party content' section before License, with link to THIRD-PARTY-NOTICES.md
- pyproject.toml: added THIRD-PARTY-NOTICES.md to wheel inclusion under [tool.hatch.build.targets.wheel.force-include]
  - File path in wheel: mcp_server_azure_architect/_THIRD-PARTY-NOTICES.md

## Validation

- ✓ manifest.json is valid JSON with license fields present
- ✓ Both sources have SPDX=MIT and properly formatted upstream_license_url
- ✓ THIRD-PARTY-NOTICES.md created with full LICENSE text from each upstream
- ✓ All internal links (README, pyproject) verified
- ✓ Refresh cadence confirmed as weekly (not monthly) per actual workflow cron
- ✓ Changes staged to correct branch atlas/95-vendoring-license-cadence

## Related issues
- Closes #95
