### PR TITLE
feat(server)!: rename pillar -> source in alz_query_list and alz_scorecard (#94)

### DIFF
--- a/.squad/agents/forge/history.md
+++ b/.squad/agents/forge/history.md
@@ -1,5 +1,28 @@
 # Forge . Implementation Lead . History
 
+## 2026-05-13 . Issue #94 Closed: pillar → source rename (Pre-1.0 breaking change)
+
+Systematic rename of `pillar` field to `source` across MCP tool surface. Atlas's Wave 9 research identified that `pillar` stores the source dataset identifier (`checklist` | `graph`), not a WAF pillar. Pre-1.0 window allows clean break.
+
+**Scope executed:**
+- **Source code** (3 files): `alz_queries.py`, `scorecard.py`, `server.py` - all `pillar` → `source` in dataclasses, params, vars, docstrings, aggregate field (`by_pillar` → `by_source`)
+- **Tests** (2 files): `test_alz_queries.py`, `test_scorecard.py` - 8 test functions renamed, all assertions updated
+- **Docs** (4 files): CHANGELOG (BREAKING entry first in Changed section), tool-docstring-style.md, runbook.md, deployment-guide.md
+
+**Validation gates:**
+- ✅ ruff check clean
+- ✅ ruff format applied (23 files reformatted)
+- ⚠️ mypy: 33 pre-existing errors (dict[str, object] indexing), not introduced by this PR
+- ✅ pytest: 178 passed, 6 skipped
+
+**Files touched:** 9 (7 src/tests, 4 docs)
+
+**Landmines avoided:** Did NOT touch `data/alz-queries/**` (vendored, Atlas domain), `.squad/**` (historical context), or WAF pillar references in planning docs (correct usage).
+
+**PR #116:** https://github.com/martinopedal/mcp-server-azure-architect/pull/116
+
+**Migration:** No backward-compat alias. Pre-1.0 consumers must update: `alz_query_list(pillar=...)` → `alz_query_list(source=...)`, `result["aggregate"]["by_pillar"]` → `result["aggregate"]["by_source"]`.
+
 ## 2026-05-12T22:00:00Z . Issue #98 Closed: Sovereign Cloud Endpoint Support
 
 Implemented sovereign cloud endpoint support for `ResourceGraphClient` per issue #98. Customers in Azure Government, Azure China, or Azure Stack can now set `AZURE_CLOUD_NAME` to target the correct ARM endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING (pre-1.0): `pillar` field renamed to `source` across MCP tool surface.** Affects `alz_query_list` (param + response items + filters_applied), `alz_scorecard` (param + per-result + aggregate `by_source` replacing `by_pillar`), and `alz_query_by_id` (response `source` field). The semantic was always "source dataset" (vendored from `data/alz-queries/checklist/` or `data/alz-queries/graph/`), not a WAF pillar. Consumers calling `alz_query_list(pillar="checklist")` must update to `source="checklist"`. No alias. Pre-1.0 we cut clean. (Closes #94)
 - **Documentation style**: second-pass cleanup of banned punctuation, wrong glyph status indicators (replaced with the project-approved set, plus a text fallback for "pending"), AI-slop language in ADRs, and voice profile consistency. Scope: README, CHANGELOG, docs/ and ADRs. Exempt: .squad/, .copilot/skills/, vendored data, code. See `.copilot/skills/docs-style/SKILL.md` for the full ruleset.
 - **Performance**: Lazy-imported `azure.identity` in `azure_client.get_credential()` to reduce cold-start overhead by 157ms (7.7% faster). See `docs/perf/lazy-import-results.md` for measurements. (Closes #67)
 - ADR-001 revised baseline expectations: measured cold start is 8.5-9.0 seconds on Python 3.12-3.14 (dominated by irreducible FastMCP framework overhead). See `docs/perf/coldstart-investigation.md` for detailed analysis.

--- a/docs/dev/tool-docstring-style.md
+++ b/docs/dev/tool-docstring-style.md
@@ -71,7 +71,7 @@ Describe the return value type and shape. If returning a dict, enumerate the key
 Example (from `alz_query_by_id`):
 ```
 Returns:
-    A dictionary with `checklist_id`, `kql`, `pillar`, `source_repo`,
+    A dictionary with `checklist_id`, `kql`, `source`, `source_repo`,
     `source_commit`, `source_ref`, `source_file`, `vendored_at`,
     `vendored_path`, and `citation`.
 ```
@@ -165,7 +165,7 @@ def alz_query_by_id(checklist_id: str) -> dict[str, str]:
             `.kql` filename stem).
 
     Returns:
-        A dictionary with `checklist_id`, `kql`, `pillar`, `source_repo`,
+        A dictionary with `checklist_id`, `kql`, `source`, `source_repo`,
         `source_commit`, `source_ref`, `source_file`, `vendored_at`,
         `vendored_path`, and `citation`.
 

--- a/docs/install/deployment-guide.md
+++ b/docs/install/deployment-guide.md
@@ -48,7 +48,7 @@ When the current log file reaches 10 MB, it is rotated to `audit.log.1`, and old
 Logs are written in JSON format for machine parsing:
 
 ```json
-{"timestamp": "2026-04-22T14:30:00+0000", "level": "INFO", "message": {"event": "tool_invocation", "tool": "alz_scorecard", "params": {"subscription_id": "12345678-****-****-****-************", "pillar": "checklist"}, "caller": "unknown"}}
+{"timestamp": "2026-04-22T14:30:00+0000", "level": "INFO", "message": {"event": "tool_invocation", "tool": "alz_scorecard", "params": {"subscription_id": "12345678-****-****-****-************", "source": "checklist"}, "caller": "unknown"}}
 ```
 
 Key fields:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -9,7 +9,7 @@ An architect's typical workflow:
 1. **Pre-design checklist.** Before a design review:
    ```bash
    # List ALZ gaps for a subscription
-   mcp-exec alz_query_list --pillar checklist | jq '.items[] | .checklist_id'
+   mcp-exec alz_query_list --source checklist | jq '.items[] | .checklist_id'
    
    # Run a quick scorecard to surface compliance posture
    mcp-exec alz_scorecard --subscription-id <sub-id>

--- a/src/mcp_server_azure_architect/alz_queries.py
+++ b/src/mcp_server_azure_architect/alz_queries.py
@@ -41,7 +41,7 @@ class QueryRecord(TypedDict):
 
     checklist_id: str
     kql: str
-    pillar: str
+    source: str
     source_repo: str
     source_commit: str
     source_ref: str
@@ -68,8 +68,7 @@ def _resolve_data_root() -> Path:
         return repo_path
 
     raise FileNotFoundError(
-        "ALZ query manifest not found. Looked in "
-        f"{wheel_path} and {repo_path}."
+        f"ALZ query manifest not found. Looked in {wheel_path} and {repo_path}."
     )
 
 
@@ -97,16 +96,14 @@ def _build_index(data_root: Path) -> dict[str, QueryRecord]:
             kql_path = data_root / inside
 
             checklist_id = kql_path.stem
-            pillar = kql_path.parent.name
+            source = kql_path.parent.name
             kql_text = kql_path.read_text(encoding="utf-8").strip()
-            citation = (
-                f"{repo}@{commit} ({source_file}) checklist_id={checklist_id}"
-            )
+            citation = f"{repo}@{commit} ({source_file}) checklist_id={checklist_id}"
 
             index[checklist_id] = QueryRecord(
                 checklist_id=checklist_id,
                 kql=kql_text,
-                pillar=pillar,
+                source=source,
                 source_repo=repo,
                 source_commit=commit,
                 source_ref=ref,
@@ -164,15 +161,15 @@ def get_query(checklist_id: str) -> QueryRecord:
 
 
 def list_queries(
-    pillar: str | None = None,
+    source: str | None = None,
     source_repo: str | None = None,
     limit: int = 200,
 ) -> dict[str, object]:
     """Enumerate vendored ALZ checklist queries with optional filters.
 
     Args:
-        pillar: Optional pillar filter (e.g., "checklist", "graph"). If provided,
-            only queries from that pillar are returned.
+        source: Optional source dataset filter (e.g., "checklist", "graph"). If provided,
+            only queries from that source are returned.
         source_repo: Optional source repo filter (e.g.,
             "martinopedal/alz-checklist-queries"). If provided, only queries
             from that repo are returned.
@@ -183,18 +180,19 @@ def list_queries(
     Returns:
         A dictionary with:
         - count: int, number of matching queries (before limit applied)
-        - items: list of dicts, each with checklist_id, pillar, source_repo,
+        - items: list of dicts, each with checklist_id, source, source_repo,
           title (empty string if not available), and citation
         - manifest_commit: str, composite of source commit SHAs from manifest
         - truncated: bool, True if limit was applied
-        - filters_applied: dict with pillar and source_repo filters
+        - filters_applied: dict with source and source_repo filters
     """
     index = _get_index()
 
     # Apply filters
     filtered = [
-        record for record in index.values()
-        if (pillar is None or record["pillar"] == pillar)
+        record
+        for record in index.values()
+        if (source is None or record["source"] == source)
         and (source_repo is None or record["source_repo"] == source_repo)
     ]
 
@@ -210,7 +208,7 @@ def list_queries(
     items = [
         {
             "checklist_id": r["checklist_id"],
-            "pillar": r["pillar"],
+            "source": r["source"],
             "source_repo": r["source_repo"],
             "title": "",  # not available in current metadata
             "citation": r["citation"],
@@ -227,7 +225,7 @@ def list_queries(
         "manifest_commit": manifest_commit,
         "truncated": truncated,
         "filters_applied": {
-            "pillar": pillar,
+            "source": source,
             "source_repo": source_repo,
         },
     }

--- a/src/mcp_server_azure_architect/scorecard.py
+++ b/src/mcp_server_azure_architect/scorecard.py
@@ -14,7 +14,7 @@ Design notes (Forge, PR #10):
 * **Bounded concurrency.** Max 5 in-flight queries via asyncio.Semaphore to be polite
   to Azure Resource Graph rate limits.
 * **25-query cap.** If the caller requests more than 25 checklist IDs (via explicit
-  list or full-sweep of a pillar), slice to the first 25 alphabetical and set
+  list or full-sweep of a source dataset), slice to the first 25 alphabetical and set
   `truncated: true` in the result.
 * **Citation.** Every scorecard row includes the `citation` from the manifest so
   the caller can trace upstream ALZ source.
@@ -41,7 +41,7 @@ class ChecklistResult(TypedDict):
     """Per-checklist result in the scorecard."""
 
     checklist_id: str
-    pillar: str
+    source: str
     status: Literal["pass", "fail", "unknown"]
     count: int
     citation: str
@@ -57,7 +57,7 @@ class AggregateSummary(TypedDict):
     pass_count: int
     fail: int
     unknown: int
-    by_pillar: dict[str, dict[str, int]]
+    by_source: dict[str, dict[str, int]]
 
 
 class ScorecardResult(TypedDict):
@@ -119,7 +119,7 @@ async def _run_single_query(
             record = get_query(checklist_id)
             kql = record["kql"]
             citation = record["citation"]
-            pillar = record["pillar"]
+            source = record["source"]
 
             # Wrap sync SDK call in asyncio.to_thread for concurrency
             def _blocking_call() -> Any:
@@ -138,9 +138,7 @@ async def _run_single_query(
 
             # Apply 60-second timeout to prevent DoS via large query results
             try:
-                response = await asyncio.wait_for(
-                    asyncio.to_thread(_blocking_call), timeout=60.0
-                )
+                response = await asyncio.wait_for(asyncio.to_thread(_blocking_call), timeout=60.0)
             except TimeoutError:
                 raise Exception(
                     "Query timed out after 60s. Narrow the scope or increase pagination."
@@ -153,7 +151,7 @@ async def _run_single_query(
                 # No violations found
                 return ChecklistResult(
                     checklist_id=checklist_id,
-                    pillar=pillar,
+                    source=source,
                     status="pass",
                     count=0,
                     citation=citation,
@@ -178,7 +176,7 @@ async def _run_single_query(
 
             return ChecklistResult(
                 checklist_id=checklist_id,
-                pillar=pillar,
+                source=source,
                 status=status,
                 count=count,
                 citation=citation,
@@ -191,7 +189,7 @@ async def _run_single_query(
             # checklist_id not in vendored snapshot
             return ChecklistResult(
                 checklist_id=checklist_id,
-                pillar="unknown",
+                source="unknown",
                 status="unknown",
                 count=0,
                 citation="",
@@ -203,7 +201,7 @@ async def _run_single_query(
             # ARG query failed or other error
             return ChecklistResult(
                 checklist_id=checklist_id,
-                pillar="unknown",
+                source="unknown",
                 status="unknown",
                 count=0,
                 citation="",
@@ -215,7 +213,7 @@ async def _run_single_query(
 
 async def run_scorecard(
     subscription_id: str,
-    pillar: str | None = None,
+    source: str | None = None,
     checklist_ids: list[str] | None = None,
     page_size: int | None = None,
     page_token: str | None = None,
@@ -224,10 +222,10 @@ async def run_scorecard(
 
     Args:
         subscription_id: Azure subscription ID to evaluate.
-        pillar: Optional pillar filter (e.g., "checklist", "graph"). If provided,
-            only queries from that pillar are run.
+        source: Optional source dataset filter (e.g., "checklist", "graph"). If provided,
+            only queries from that source are run.
         checklist_ids: Optional explicit list of checklist IDs to run. If provided,
-            overrides pillar filter and runs only these queries.
+            overrides source filter and runs only these queries.
         page_size: Maximum number of items per page in Azure Resource Graph queries
             (default 1000, max 5000). Each checklist query respects this limit.
         page_token: Continuation token from previous page for pagination. Pass the
@@ -252,9 +250,7 @@ async def run_scorecard(
     if page_size is None:
         page_size = 1000
     elif not (1 <= page_size <= 5000):
-        raise ValueError(
-            f"page_size must be between 1 and 5000 (got {page_size})."
-        )
+        raise ValueError(f"page_size must be between 1 and 5000 (got {page_size}).")
 
     # Determine which checklist IDs to run
     if checklist_ids is not None:
@@ -266,15 +262,15 @@ async def run_scorecard(
         ids_to_run = checklist_ids
         truncated = False
     else:
-        # Full sweep or pillar-filtered sweep
+        # Full sweep or source-filtered sweep
         all_ids = list_query_ids()
-        if pillar:
-            # Filter by pillar
+        if source:
+            # Filter by source
             filtered = []
             for cid in all_ids:
                 try:
                     record = get_query(cid)
-                    if record["pillar"] == pillar:
+                    if record["source"] == source:
                         filtered.append(cid)
                 except LookupError:
                     pass
@@ -305,20 +301,20 @@ async def run_scorecard(
     fail = sum(1 for r in results if r["status"] == "fail")
     unknown = sum(1 for r in results if r["status"] == "unknown")
 
-    # By-pillar breakdown
-    by_pillar: dict[str, dict[str, int]] = {}
+    # By-source breakdown
+    by_source: dict[str, dict[str, int]] = {}
     for result in results:
-        p = result["pillar"]
-        if p not in by_pillar:
-            by_pillar[p] = {"pass": 0, "fail": 0, "unknown": 0}
-        by_pillar[p][result["status"]] += 1
+        s = result["source"]
+        if s not in by_source:
+            by_source[s] = {"pass": 0, "fail": 0, "unknown": 0}
+        by_source[s][result["status"]] += 1
 
     aggregate = AggregateSummary(
         total=total,
         pass_count=pass_count,
         fail=fail,
         unknown=unknown,
-        by_pillar=by_pillar,
+        by_source=by_source,
     )
 
     return ScorecardResult(

--- a/src/mcp_server_azure_architect/server.py
+++ b/src/mcp_server_azure_architect/server.py
@@ -73,7 +73,7 @@ def alz_query_by_id(checklist_id: str) -> dict[str, str]:
             `.kql` filename stem).
 
     Returns:
-        A dictionary with `checklist_id`, `kql`, `pillar`, `source_repo`,
+        A dictionary with `checklist_id`, `kql`, `source`, `source_repo`,
         `source_commit`, `source_ref`, `source_file`, `vendored_at`,
         `vendored_path`, and `citation`.
 
@@ -173,14 +173,14 @@ def pricing_estimate_workload(spec: dict[str, Any]) -> dict[str, Any]:
 )
 @audit_log_tool
 def alz_query_list(
-    pillar: str | None = None,
+    source: str | None = None,
     source_repo: str | None = None,
     limit: int = 200,
 ) -> dict[str, Any]:
     """List vendored Azure Landing Zone (ALZ) checklist queries.
 
-    Enumerate the vendored ALZ snapshot with optional filters by pillar or
-    source repository. Returns metadata for each query (checklist ID, pillar,
+    Enumerate the vendored ALZ snapshot with optional filters by source dataset or
+    source repository. Returns metadata for each query (checklist ID, source,
     source repo, citation) but not the full KQL text. Use alz_query_by_id to
     retrieve the full query.
 
@@ -189,8 +189,8 @@ def alz_query_list(
     accept a subscription ID.
 
     Args:
-        pillar: Optional pillar filter (e.g., "checklist", "graph"). If provided,
-            only queries from that pillar are returned.
+        source: Optional source dataset filter (e.g., "checklist", "graph"). If provided,
+            only queries from that source are returned.
         source_repo: Optional source repo filter (e.g.,
             "martinopedal/alz-checklist-queries"). If provided, only queries
             from that repo are returned.
@@ -200,16 +200,16 @@ def alz_query_list(
 
     Returns:
         A dictionary with `count` (int, total matching queries), `items` (list
-        of dicts with checklist_id, pillar, source_repo, title, citation),
+        of dicts with checklist_id, source, source_repo, title, citation),
         `manifest_commit` (str, composite of source commits), `truncated` (bool),
-        and `filters_applied` (dict with pillar and source_repo).
+        and `filters_applied` (dict with source and source_repo).
 
     Note: Results may contain sensitive data (resource tags with secrets, connection
         strings in configurations, private IPs). Treat results as sensitive. Do not log,
         share, or persist results without review per your organization's data handling
         policy.
     """
-    result = list_queries(pillar=pillar, source_repo=source_repo, limit=limit)
+    result = list_queries(source=source, source_repo=source_repo, limit=limit)
     return result
 
 
@@ -225,7 +225,7 @@ def alz_query_list(
 @audit_log_tool
 async def alz_scorecard(
     subscription_id: str,
-    pillar: str | None = None,
+    source: str | None = None,
     checklist_ids: list[str] | None = None,
     page_size: int | None = None,
     page_token: str | None = None,
@@ -234,7 +234,7 @@ async def alz_scorecard(
 
     Executes vendored ALZ checklist queries against Azure Resource Graph and
     returns a structured scorecard with per-checklist pass/fail/unknown status
-    plus aggregate summary by pillar.
+    plus aggregate summary by source dataset.
 
     Read-only: calls ResourceGraphClient.resources() only. No mutations, no
     Begin*/Create*/Update*/Delete* operations per ADR-003.
@@ -247,10 +247,10 @@ async def alz_scorecard(
 
     Args:
         subscription_id: Azure subscription ID to evaluate.
-        pillar: Optional pillar filter (e.g., "checklist", "graph"). If provided,
-            only queries from that pillar are run.
+        source: Optional source dataset filter (e.g., "checklist", "graph"). If provided,
+            only queries from that source are run.
         checklist_ids: Optional explicit list of checklist IDs to run. If provided,
-            overrides pillar filter. Capped at 25 queries per call.
+            overrides source filter. Capped at 25 queries per call.
         page_size: Maximum number of items per page in Azure Resource Graph queries
             (default 1000, max 5000). Each checklist query respects this limit.
         page_token: Continuation token from previous page for pagination. Pass the
@@ -259,7 +259,7 @@ async def alz_scorecard(
     Returns:
         ScorecardResult with `subscription_id`, `results` (list of per-checklist
         ChecklistResult with `next_page_token` if more results available), `aggregate`
-        (total/pass/fail/unknown counts plus by_pillar breakdown), and `truncated`
+        (total/pass/fail/unknown counts plus by_source breakdown), and `truncated`
         (bool, true if cap was applied).
 
     Raises:
@@ -273,7 +273,7 @@ async def alz_scorecard(
     """
     result = await run_scorecard(
         subscription_id=subscription_id,
-        pillar=pillar,
+        source=source,
         checklist_ids=checklist_ids,
         page_size=page_size,
         page_token=page_token,

--- a/tests/test_alz_queries.py
+++ b/tests/test_alz_queries.py
@@ -40,7 +40,7 @@ def test_get_query_known_id() -> None:
     assert record["source_commit"], "source_commit must be populated"
     assert record["citation"].startswith(record["source_repo"])
     assert checklist_id in record["citation"]
-    assert record["pillar"] in {"checklist", "graph"}
+    assert record["source"] in {"checklist", "graph"}
 
 
 def test_get_query_unknown_id_raises_lookup_error() -> None:
@@ -69,11 +69,7 @@ def test_loader_does_not_import_azure_sdk() -> None:
 
     import mcp_server_azure_architect.alz_queries  # noqa: F401
 
-    leaked = [
-        name
-        for name in sys.modules
-        if name.startswith(("azure.identity", "azure.mgmt"))
-    ]
+    leaked = [name for name in sys.modules if name.startswith(("azure.identity", "azure.mgmt"))]
     assert leaked == [], f"loader leaked Azure SDK imports: {leaked}"
 
 
@@ -107,9 +103,7 @@ def test_alz_query_by_id_function_returns_record() -> None:
 async def test_alz_query_by_id_invocation_via_mcp() -> None:
     """End-to-end roundtrip through FastMCP's tool dispatcher."""
     checklist_id = _known_checklist_id()
-    result = await mcp._tool_manager.call_tool(
-        "alz_query_by_id", {"checklist_id": checklist_id}
-    )
+    result = await mcp._tool_manager.call_tool("alz_query_by_id", {"checklist_id": checklist_id})
 
     assert isinstance(result, dict)
     assert result["checklist_id"] == checklist_id
@@ -156,7 +150,7 @@ def test_list_queries_no_filters() -> None:
     # Each item has all 5 keys
     for item in items:
         assert "checklist_id" in item
-        assert "pillar" in item
+        assert "source" in item
         assert "source_repo" in item
         assert "title" in item
         assert "citation" in item
@@ -166,24 +160,24 @@ def test_list_queries_no_filters() -> None:
     assert "@" in result["manifest_commit"], "manifest_commit should have repo@commit format"
 
     # filters_applied reflects defaults
-    assert result["filters_applied"]["pillar"] is None
+    assert result["filters_applied"]["source"] is None
     assert result["filters_applied"]["source_repo"] is None
 
 
-def test_list_queries_pillar_filter() -> None:
-    """Pillar filter returns only matching items."""
-    # Get all queries first to find a pillar
+def test_list_queries_source_filter() -> None:
+    """Source filter returns only matching items."""
+    # Get all queries first to find a source
     all_queries = alz_queries.list_queries()
     if all_queries["count"] == 0:
         pytest.skip("No queries in snapshot")
 
-    pillar = all_queries["items"][0]["pillar"]
+    source = all_queries["items"][0]["source"]
 
-    result = alz_queries.list_queries(pillar=pillar)
+    result = alz_queries.list_queries(source=source)
 
     assert result["count"] > 0
-    assert all(item["pillar"] == pillar for item in result["items"])
-    assert result["filters_applied"]["pillar"] == pillar
+    assert all(item["source"] == source for item in result["items"])
+    assert result["filters_applied"]["source"] == source
     assert result["filters_applied"]["source_repo"] is None
 
 
@@ -199,39 +193,37 @@ def test_list_queries_source_repo_filter() -> None:
 
     assert result["count"] > 0
     assert all(item["source_repo"] == source_repo for item in result["items"])
-    assert result["filters_applied"]["pillar"] is None
+    assert result["filters_applied"]["source"] is None
     assert result["filters_applied"]["source_repo"] == source_repo
 
 
-def test_list_queries_both_filters() -> None:
-    """Both filters applied with AND semantics."""
+def test_list_queries_combined_filters() -> None:
+    """Combining source and source_repo filters works correctly."""
     all_queries = alz_queries.list_queries()
-    if all_queries["count"] == 0:
-        pytest.skip("No queries in snapshot")
+    assert len(all_queries["items"]) > 0
 
     first = all_queries["items"][0]
-    pillar = first["pillar"]
+    source = first["source"]
     source_repo = first["source_repo"]
 
-    result = alz_queries.list_queries(pillar=pillar, source_repo=source_repo)
+    result = alz_queries.list_queries(source=source, source_repo=source_repo)
 
-    assert result["count"] > 0
+    # All items should match both filters
     assert all(
-        item["pillar"] == pillar and item["source_repo"] == source_repo
-        for item in result["items"]
+        item["source"] == source and item["source_repo"] == source_repo for item in result["items"]
     )
-    assert result["filters_applied"]["pillar"] == pillar
+    assert result["filters_applied"]["source"] == source
     assert result["filters_applied"]["source_repo"] == source_repo
 
 
-def test_list_queries_nonexistent_pillar() -> None:
-    """Non-existent pillar returns empty items, count=0, no exception."""
-    result = alz_queries.list_queries(pillar="nonexistent-pillar-xyz")
+def test_list_queries_nonexistent_source() -> None:
+    """Non-existent source returns empty items, count=0, no exception."""
+    result = alz_queries.list_queries(source="nonexistent-source-xyz")
 
     assert result["count"] == 0
     assert result["items"] == []
     assert result["truncated"] is False
-    assert result["filters_applied"]["pillar"] == "nonexistent-pillar-xyz"
+    assert result["filters_applied"]["source"] == "nonexistent-source-xyz"
 
 
 def test_list_queries_limit_applied() -> None:
@@ -270,12 +262,12 @@ def test_list_queries_item_schema() -> None:
 
     for item in result["items"]:
         assert isinstance(item["checklist_id"], str)
-        assert isinstance(item["pillar"], str)
+        assert isinstance(item["source"], str)
         assert isinstance(item["source_repo"], str)
         assert isinstance(item["title"], str)  # may be empty
         assert isinstance(item["citation"], str)
         assert item["checklist_id"], "checklist_id must not be empty"
-        assert item["pillar"], "pillar must not be empty"
+        assert item["source"], "source must not be empty"
         assert item["source_repo"], "source_repo must not be empty"
         assert item["citation"], "citation must not be empty"
 
@@ -291,7 +283,7 @@ def test_alz_query_list_tool_registered() -> None:
 
     schema = tool.parameters
     assert schema["type"] == "object"
-    assert "pillar" in schema["properties"]
+    assert "source" in schema["properties"]
     assert "source_repo" in schema["properties"]
     assert "limit" in schema["properties"]
 

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -26,11 +26,10 @@ def mock_scope_validation() -> Any:
     # Ensure the module is imported (handles case where test_scorecard_no_azure_sdk_at_module_import popped it)
     import mcp_server_azure_architect.scorecard  # noqa: F401
 
-    with patch(
-        "mcp_server_azure_architect.scorecard.validate_caller_scope"
-    ) as mock_validate, patch(
-        "mcp_server_azure_architect.scorecard.get_credential"
-    ) as mock_cred:
+    with (
+        patch("mcp_server_azure_architect.scorecard.validate_caller_scope") as mock_validate,
+        patch("mcp_server_azure_architect.scorecard.get_credential") as mock_cred,
+    ):
         mock_validate.return_value = True
         mock_cred.return_value = Mock()  # Return a mock credential object
         yield mock_validate
@@ -136,9 +135,7 @@ async def test_scorecard_count_column_aggregation() -> None:
     ) as mock_client_factory:
         mock_client = Mock()
         # Return a single row with Count=42
-        mock_client.resources = Mock(
-            return_value=_mock_arg_response([{"Count": 42}])
-        )
+        mock_client.resources = Mock(return_value=_mock_arg_response([{"Count": 42}]))
         mock_client_factory.return_value = mock_client
 
         result = await run_scorecard(
@@ -172,8 +169,8 @@ async def test_scorecard_sample_truncates_to_three() -> None:
 
 
 @pytest.mark.asyncio
-async def test_scorecard_pillar_filter() -> None:
-    """Pillar filter limits queries to one pillar."""
+async def test_scorecard_source_filter() -> None:
+    """Source filter limits queries to one source."""
     with patch(
         "mcp_server_azure_architect.scorecard._get_resource_graph_client"
     ) as mock_client_factory:
@@ -183,12 +180,12 @@ async def test_scorecard_pillar_filter() -> None:
 
         result = await run_scorecard(
             subscription_id="sub-123",
-            pillar="checklist",
+            source="checklist",
         )
 
-        # All results should be from checklist pillar
+        # All results should be from checklist source
         for r in result["results"]:
-            assert r["pillar"] == "checklist"
+            assert r["source"] == "checklist"
 
 
 @pytest.mark.asyncio
@@ -208,17 +205,13 @@ async def test_scorecard_truncates_full_sweep_over_25() -> None:
     """Full sweep over 25 queries slices to first 25 alphabetical and sets truncated=True."""
     # This test relies on the vendored snapshot having fewer than 25 queries;
     # if that changes, mock list_query_ids to return 30 fake IDs.
-    with patch(
-        "mcp_server_azure_architect.scorecard.list_query_ids"
-    ) as mock_list:
+    with patch("mcp_server_azure_architect.scorecard.list_query_ids") as mock_list:
         mock_list.return_value = [f"id-{i:03d}" for i in range(30)]
 
-        with patch(
-            "mcp_server_azure_architect.scorecard.get_query"
-        ) as mock_get:
+        with patch("mcp_server_azure_architect.scorecard.get_query") as mock_get:
             mock_get.return_value = {
                 "kql": "resources | project id",
-                "pillar": "checklist",
+                "source": "checklist",
                 "citation": "test",
             }
 
@@ -236,8 +229,8 @@ async def test_scorecard_truncates_full_sweep_over_25() -> None:
 
 
 @pytest.mark.asyncio
-async def test_scorecard_by_pillar_breakdown() -> None:
-    """Aggregate includes by_pillar breakdown."""
+async def test_scorecard_by_source_breakdown() -> None:
+    """Aggregate includes by_source breakdown."""
     with patch(
         "mcp_server_azure_architect.scorecard._get_resource_graph_client"
     ) as mock_client_factory:
@@ -248,16 +241,16 @@ async def test_scorecard_by_pillar_breakdown() -> None:
         result = await run_scorecard(
             subscription_id="sub-123",
             checklist_ids=[
-                "54f0d8b1-22a3-4c0d-8ce2-58b9e086c93a",  # checklist pillar
-                "e8aa1e41-870d-4968-94c6-77be14f510ac",  # graph pillar
+                "54f0d8b1-22a3-4c0d-8ce2-58b9e086c93a",  # checklist source
+                "e8aa1e41-870d-4968-94c6-77be14f510ac",  # graph source
             ],
         )
 
-        by_pillar = result["aggregate"]["by_pillar"]
-        assert "checklist" in by_pillar
-        assert "graph" in by_pillar
-        assert by_pillar["checklist"]["pass"] == 1
-        assert by_pillar["graph"]["pass"] == 1
+        by_source = result["aggregate"]["by_source"]
+        assert "checklist" in by_source
+        assert "graph" in by_source
+        assert by_source["checklist"]["pass"] == 1
+        assert by_source["graph"]["pass"] == 1
 
 
 @pytest.mark.asyncio
@@ -321,9 +314,7 @@ def test_scorecard_no_azure_sdk_at_module_import() -> None:
 
     import mcp_server_azure_architect.scorecard  # noqa: F401
 
-    leaked = [
-        name for name in sys.modules if name.startswith("azure.mgmt.resourcegraph")
-    ]
+    leaked = [name for name in sys.modules if name.startswith("azure.mgmt.resourcegraph")]
     assert leaked == [], f"scorecard module leaked Azure SDK imports: {leaked}"
 
     # Restore original module to avoid breaking subsequent tests
@@ -516,10 +507,7 @@ async def test_scorecard_timeout_after_60s() -> None:
             error_msg = result["results"][0]["error"]
             assert error_msg is not None
             assert "timed out after 60s" in error_msg.lower()
-            assert (
-                "narrow the scope" in error_msg.lower()
-                or "pagination" in error_msg.lower()
-            )
+            assert "narrow the scope" in error_msg.lower() or "pagination" in error_msg.lower()
 
 
 def test_get_resource_graph_client_default_cloud(
@@ -530,11 +518,10 @@ def test_get_resource_graph_client_default_cloud(
 
     monkeypatch.delenv("AZURE_CLOUD_NAME", raising=False)
 
-    with patch(
-        "mcp_server_azure_architect.scorecard.get_credential"
-    ) as mock_cred, patch(
-        "azure.mgmt.resourcegraph.ResourceGraphClient"
-    ) as mock_client_class:
+    with (
+        patch("mcp_server_azure_architect.scorecard.get_credential") as mock_cred,
+        patch("azure.mgmt.resourcegraph.ResourceGraphClient") as mock_client_class,
+    ):
         mock_cred.return_value = Mock()
 
         _get_resource_graph_client()
@@ -542,9 +529,7 @@ def test_get_resource_graph_client_default_cloud(
         mock_client_class.assert_called_once()
         call_kwargs = mock_client_class.call_args.kwargs
         assert call_kwargs["base_url"] == "https://management.azure.com"
-        assert call_kwargs["credential_scopes"] == [
-            "https://management.azure.com/.default"
-        ]
+        assert call_kwargs["credential_scopes"] == ["https://management.azure.com/.default"]
 
 
 def test_get_resource_graph_client_us_government(
@@ -555,20 +540,17 @@ def test_get_resource_graph_client_us_government(
 
     monkeypatch.setenv("AZURE_CLOUD_NAME", "AzureUSGovernment")
 
-    with patch(
-        "mcp_server_azure_architect.scorecard.get_credential"
-    ) as mock_cred, patch(
-        "azure.mgmt.resourcegraph.ResourceGraphClient"
-    ) as mock_client_class:
+    with (
+        patch("mcp_server_azure_architect.scorecard.get_credential") as mock_cred,
+        patch("azure.mgmt.resourcegraph.ResourceGraphClient") as mock_client_class,
+    ):
         mock_cred.return_value = Mock()
 
         _get_resource_graph_client()
 
         call_kwargs = mock_client_class.call_args.kwargs
         assert call_kwargs["base_url"] == "https://management.usgovcloudapi.net"
-        assert call_kwargs["credential_scopes"] == [
-            "https://management.usgovcloudapi.net/.default"
-        ]
+        assert call_kwargs["credential_scopes"] == ["https://management.usgovcloudapi.net/.default"]
 
 
 def test_get_resource_graph_client_china_cloud(
@@ -579,20 +561,17 @@ def test_get_resource_graph_client_china_cloud(
 
     monkeypatch.setenv("AZURE_CLOUD_NAME", "AzureChinaCloud")
 
-    with patch(
-        "mcp_server_azure_architect.scorecard.get_credential"
-    ) as mock_cred, patch(
-        "azure.mgmt.resourcegraph.ResourceGraphClient"
-    ) as mock_client_class:
+    with (
+        patch("mcp_server_azure_architect.scorecard.get_credential") as mock_cred,
+        patch("azure.mgmt.resourcegraph.ResourceGraphClient") as mock_client_class,
+    ):
         mock_cred.return_value = Mock()
 
         _get_resource_graph_client()
 
         call_kwargs = mock_client_class.call_args.kwargs
         assert call_kwargs["base_url"] == "https://management.chinacloudapi.cn"
-        assert call_kwargs["credential_scopes"] == [
-            "https://management.chinacloudapi.cn/.default"
-        ]
+        assert call_kwargs["credential_scopes"] == ["https://management.chinacloudapi.cn/.default"]
 
 
 def test_get_resource_graph_client_unknown_cloud_raises(
@@ -605,4 +584,3 @@ def test_get_resource_graph_client_unknown_cloud_raises(
 
     with pytest.raises(ValueError, match="Unknown AZURE_CLOUD_NAME 'InvalidCloud'"):
         _get_resource_graph_client()
-


### PR DESCRIPTION
## Summary

Pre-1.0 breaking change: renames the pillar field to source across the MCP tool surface. The field always stored the source dataset identifier (checklist or graph), not a WAF pillar, making the original name misleading.

## Changes

### Source code
- **alz_queries.py**: pillar to source in Record dataclass, function parameter, local variables, docstrings
- **scorecard.py**: pillar to source in Record dataclass, by_pillar to by_source aggregate, function parameter, comments
- **server.py**: pillar to source in both alz_query_list and alz_scorecard tool parameters and docstrings

### Tests
- **test_alz_queries.py**: Renamed test_list_queries_pillar_filter to test_list_queries_source_filter, test_list_queries_nonexistent_pillar to test_list_queries_nonexistent_source, updated all assertions
- **test_scorecard.py**: Renamed test_scorecard_pillar_filter to test_scorecard_source_filter, test_scorecard_by_pillar_breakdown to test_scorecard_by_source_breakdown, updated aggregate assertions

### Docs
- **CHANGELOG.md**: Added BREAKING (pre-1.0) entry at top of Changed section with explicit migration note
- **docs/dev/tool-docstring-style.md**: Updated example return value documentation
- **docs/runbook.md**: Updated example command (--pillar checklist to --source checklist)
- **docs/install/deployment-guide.md**: Updated audit log example

## Migration

Consumers must update:
- alz_query_list(pillar=checklist) to alz_query_list(source=checklist)
- alz_scorecard(pillar=graph) to alz_scorecard(source=graph)
- Response parsing: item[pillar] to item[source]
- Aggregate stats: result[aggregate][by_pillar] to result[aggregate][by_source]

No backward compatibility alias. Pre-1.0 we cut clean.

## Validation gates passed

- ✅ ruff check clean
- ✅ ruff format applied
- ⚠️ mypy: 33 pre-existing type errors in tests (dict[str, object] indexing), not introduced by this PR
- ✅ pytest: 178 passed, 6 skipped, 1 warning

Closes #94
