### PR TITLE
docs: fix README cold-start claim and SKILL.md tool count drift

### DIFF
--- a/.copilot/skills/docs-style/SKILL.md
+++ b/.copilot/skills/docs-style/SKILL.md
@@ -81,9 +81,9 @@ Replace or remove (case-insensitive match):
 ```markdown
 # Getting started with the server
 
-The server exposes six native tools for Azure architects: alz_query_by_id, 
-alz_query_list, pricing_lookup_sku, pricing_compare_skus, alz_scorecard, 
-and health_check. Use it for named checklist queries and scorecard 
+The server exposes seven native tools for Azure architects: alz_query_by_id, 
+alz_query_list, pricing_lookup_sku, pricing_compare_skus, pricing_estimate_workload, 
+alz_scorecard, and health_check. Use it for named checklist queries and scorecard 
 composition. For raw Azure APIs (Resource Graph, Advisor, Monitor), use 
 azure-mcp directly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/perf/importtime-baseline-3.14.log` - Raw Python importtime trace (first 200 lines)
 - `docs/install/deployment-guide.md` - Deployment configuration and hardening guidance covering audit logging setup (append-only on Linux, Windows Event Log forwarding, cloud log ingestion to Azure Monitor Logs or syslog), log retention policy (90+ days minimum for compliance), and security best practices (non-privileged user, restricted permissions, network isolation, credential management). Addresses Threat R2 (log tampering). (#59)
 - `docs/install/usage-guide.md` - End-user guide for safe invocation of query tools covering sensitive data handling (connection strings, resource tags, private IPs, role assignments), scope guidance (prefer resource group over subscription, one subscription per call), result handling best practices (local processing, redaction before sharing, archive with access controls), and organizational policy template. Addresses Threat I2 (sensitive data exposure). (#60)
+- README.md: Removed inaccurate cold-start claim. Replaced with link to `docs/perf/coldstart-investigation.md` for measured baseline (8.5-9.0s on Python 3.12-3.14, dominated by FastMCP framework overhead). Fixes discrepancy between README claim and ADR-001 planning estimate.
+- `.copilot/skills/docs-style/SKILL.md`: Fixed tool count drift. Updated from "six native tools" to "seven native tools" and added `pricing_estimate_workload` to the list (added in PR #87).
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Python 3.11+ with FastMCP, per [ADR-001](docs/adr/0001-runtime-choice.md). Build
 
 Constraints:
 
-- Local-first, single binary or single-process startup. Cold-start budget under 1 second on Python 3.12 (per ADR-001 measurements).
+- Local-first, single binary or single-process startup. Cold-start performance is documented in [docs/perf/coldstart-investigation.md](docs/perf/coldstart-investigation.md).
 - Read-only Azure SDK calls only. DefaultAzureCredential exclusively.
 - Zero credentials at rest. Token-scrub on any logging.
 - ALZ checklist queries source from the public `martinopedal/alz-checklist-queries` and `martinopedal/alz-graph-queries` repos (vendored snapshot, pinned by upstream commit SHA).


### PR DESCRIPTION
## Summary

Two documentation corrections to fix discrepancies between README, SKILL.md, and source-of-truth docs.

## Fix 1: README.md cold-start claim (line 56)

**Problem:** README claimed 'Cold-start budget under 1 second on Python 3.12 (per ADR-001 measurements).' This is incorrect.

- ADR-001 line 133 presents '200-800ms' as a planning estimate, not measured baseline.
- Actual measured baseline per [docs/perf/coldstart-investigation.md](https://github.com/martinopedal/mcp-server-azure-architect/blob/main/docs/perf/coldstart-investigation.md): 8.5-9.0 seconds on Python 3.12-3.14 (dominated by irreducible FastMCP framework overhead, ~85% of total).

**Solution:** Removed the inaccurate claim. Replaced with accurate link to coldstart-investigation.md, pointing readers to measured data rather than a false assertion.

New line 56:
\\\
- Local-first, single binary or single-process startup. Cold-start performance is documented in [docs/perf/coldstart-investigation.md](docs/perf/coldstart-investigation.md).
\\\

## Fix 2: SKILL.md tool count drift (lines 84-88)

**Problem:** SKILL.md said 'six native tools' and omitted pricing_estimate_workload from the list.

**Reality:**
- PR #87 added pricing_estimate_workload (native tool).
- README.md line 21 correctly lists seven tools and was updated in PR #120.
- SKILL.md example still showed six tools and old list.

**Solution:** Updated SKILL.md to match README.md line 21 wording and tool list. Changed 'six' to 'seven' and added pricing_estimate_workload in alphabetical order with the others.

New lines 84-88:
\\\markdown
The server exposes seven native tools for Azure architects: alz_query_by_id, 
alz_query_list, pricing_lookup_sku, pricing_compare_skus, pricing_estimate_workload, 
alz_scorecard, and health_check.
\\\

## CHANGELOG

Updated [CHANGELOG.md](https://github.com/martinopedal/mcp-server-azure-architect/blob/chore/doc-freshness-fixes/CHANGELOG.md) Documentation section with both fixes.

## Files changed

- README.md: 1 line (removed false claim, added accurate link)
- .copilot/skills/docs-style/SKILL.md: 5 lines (updated count, added pricing_estimate_workload)
- CHANGELOG.md: 2 lines (documented both fixes)

## Commit

\4164511\ - docs: fix README cold-start claim and SKILL.md tool count drift