### PR TITLE
chore(ci): add ruff format --check gate (closes #117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run ruff check
         run: ruff check .
       
+      - name: Run ruff format check
+        run: ruff format --check .
+      
       - name: Run mypy
         run: mypy src
       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Readonly-check workflow now runs on all PRs.** Removed `paths:` filter from `.github/workflows/readonly-check.yml` to fix doc-only PR blocking issue. The workflow always runs on every PR + push; it is a fast check (~30s) and correctly reports "no violations" for doc-only changes. This unblocks doc-only PRs while preserving the read-only enforcement gate as a required status check.
 
+### Automation
+
+- **CI now enforces ruff format consistency.** New required check `ruff format --check .` runs on every PR after the lint step. Prevents format drift. Ruff version pinned to `0.15.12` in `pyproject.toml` to ensure reproducible formatting across local and CI environments. (Closes #117)
+
 ### Documentation
 
 - `docs/install/deployment-guide.md` - Audit logging configuration guide with log rotation settings, sensitive data redaction policies, immutable log storage upgrade paths (syslog, Azure Monitor), and cross-platform permission enforcement details

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,16 @@ Every PR runs:
 - CodeQL
 - MCP Inspector smoke test (server starts, tools enumerate, schemas validate)
 
+Before pushing, run locally:
+
+```bash
+ruff check .
+ruff format --check .
+mypy src
+pytest -v
+python scripts/verify_query_integrity.py
+```
+
 ## Identifier provenance
 
 Any hard-coded Azure identifier (policy ID, initiative ID, role definition ID, recommendation ID, ALZ checklist item ID) must be tagged with one of:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "ruff>=0.3.0",
+    "ruff==0.15.12",
     "mypy>=1.9.0",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/scripts/check_readonly.py
+++ b/scripts/check_readonly.py
@@ -44,9 +44,7 @@ READONLY_ALLOW_MARKER = "readonly-allow:"
 class ReadOnlyViolation:
     """A detected mutation method call."""
 
-    def __init__(
-        self, file_path: Path, line_number: int, method_name: str, context: str
-    ):
+    def __init__(self, file_path: Path, line_number: int, method_name: str, context: str):
         self.file_path = file_path
         self.line_number = line_number
         self.method_name = method_name
@@ -168,9 +166,7 @@ def format_suggestions(violation: ReadOnlyViolation) -> str:
     elif method.startswith("delete_") or method.startswith("remove_"):
         suggestions.append("- Use list_* to enumerate resources without deletion")
     elif method.startswith("begin_"):
-        suggestions.append(
-            "- Avoid long-running operations (LROs); use read-only queries instead"
-        )
+        suggestions.append("- Avoid long-running operations (LROs); use read-only queries instead")
     elif method.startswith("start_") or method.startswith("stop_"):
         suggestions.append("- Use get_* to read resource state without control actions")
     else:

--- a/scripts/install_kit.py
+++ b/scripts/install_kit.py
@@ -82,7 +82,9 @@ def get_config_path(client: str) -> Path | None:
         if system == "Windows":
             return home / "AppData" / "Roaming" / "Claude" / "claude_desktop_config.json"
         elif system == "Darwin":
-            return home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+            return (
+                home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+            )
         else:
             return home / ".config" / "Claude" / "claude_desktop_config.json"
 
@@ -130,13 +132,12 @@ def load_existing_config(path: Path) -> dict[str, Any]:
             shutil.copy2(path, backup_path)
             print(f"Backup saved to {backup_path}")
 
-    return {
-        "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {}
-    }
+    return {"$schema": "https://aka.ms/mcp-config-schema", "mcpServers": {}}
 
 
-def merge_configs(existing: dict[str, Any], curated: dict[str, Any], interactive: bool = True) -> dict[str, Any]:
+def merge_configs(
+    existing: dict[str, Any], curated: dict[str, Any], interactive: bool = True
+) -> dict[str, Any]:
     """
     Merge curated config into existing, preserving existing servers.
 
@@ -255,7 +256,9 @@ def prompt_clients(detected: list[str]) -> list[str]:
         marker = "✓" if client in detected else " "
         print(f"  {idx}. [{marker}] {client}")
 
-    print("\nEnter client numbers to configure (comma-separated, e.g., '1,2,4'), or 'all': ", end="")
+    print(
+        "\nEnter client numbers to configure (comma-separated, e.g., '1,2,4'), or 'all': ", end=""
+    )
     response = input().strip().lower()
 
     if response == "all":
@@ -308,11 +311,15 @@ def main() -> int:
         return 1
 
     if not prereqs["node"][0]:
-        print("\nWarning: Node.js not found. npx-based companions (azure-mcp, mermaid, drawio, kubernetes) will not work.")
+        print(
+            "\nWarning: Node.js not found. npx-based companions (azure-mcp, mermaid, drawio, kubernetes) will not work."
+        )
         print("Install from https://nodejs.org")
 
     if not prereqs["docker"][0]:
-        print("\nWarning: Docker not found. Docker-based companions (github, terraform) will not work.")
+        print(
+            "\nWarning: Docker not found. Docker-based companions (github, terraform) will not work."
+        )
         print("Install Docker Desktop from https://docker.com")
 
     # Step 2: Install this server
@@ -381,7 +388,9 @@ def main() -> int:
     print(f"  {status_gh} GitHub: {gh_msg}")
 
     if not az_ok:
-        print("\nWarning: Azure CLI not authenticated. Run 'az login' before using azure-mcp or this server.")
+        print(
+            "\nWarning: Azure CLI not authenticated. Run 'az login' before using azure-mcp or this server."
+        )
 
     if not gh_ok:
         print("\nWarning: GitHub CLI not authenticated. The 'github' companion will not work.")

--- a/scripts/refresh_alz_snapshot.py
+++ b/scripts/refresh_alz_snapshot.py
@@ -159,7 +159,9 @@ def extract_queries_from_graph_repo(clone_dir: Path, dest_dir: Path) -> list[str
     for item in data["queries"]:
         # Validate each item has required fields
         if "guid" not in item or "graph" not in item:
-            print(f"Warning: skipping item missing 'guid' or 'graph': {item.get('guid', 'unknown')}")
+            print(
+                f"Warning: skipping item missing 'guid' or 'graph': {item.get('guid', 'unknown')}"
+            )
             continue
 
         query_id = item["guid"]
@@ -279,7 +281,9 @@ def refresh_snapshot(dry_run: bool = False) -> bool:
                 new_sources.append(existing)
             continue
 
-        print(f"  Drift detected: {pinned_sha[:12] if pinned_sha else 'none'} -> {upstream_sha[:12]}")
+        print(
+            f"  Drift detected: {pinned_sha[:12] if pinned_sha else 'none'} -> {upstream_sha[:12]}"
+        )
         changes_detected = True
 
         if dry_run:

--- a/scripts/verify_query_integrity.py
+++ b/scripts/verify_query_integrity.py
@@ -56,7 +56,9 @@ def generate_markdown_manifest(manifest: dict[str, Any], repo_root: Path) -> str
     if timestamps:
         lines.append(f"Vendored at: {max(timestamps)}")
     lines.append("")
-    lines.append("This snapshot is pinned to commit SHAs. No `main` or `latest` references are used for source content.")
+    lines.append(
+        "This snapshot is pinned to commit SHAs. No `main` or `latest` references are used for source content."
+    )
     lines.append("")
     lines.append("## Sources")
     lines.append("")
@@ -169,9 +171,7 @@ def update_hashes(repo_root: Path) -> int:
 
 def main() -> int:
     """Main entry point."""
-    parser = argparse.ArgumentParser(
-        description="Verify SHA-256 integrity of vendored ALZ queries"
-    )
+    parser = argparse.ArgumentParser(description="Verify SHA-256 integrity of vendored ALZ queries")
     parser.add_argument(
         "--update",
         action="store_true",

--- a/src/mcp_server_azure_architect/_clouds.py
+++ b/src/mcp_server_azure_architect/_clouds.py
@@ -71,9 +71,6 @@ def get_cloud_config() -> CloudConfig:
 
     if cloud_name not in _CLOUD_MAP:
         valid_clouds = ", ".join(_CLOUD_MAP.keys())
-        raise ValueError(
-            f"Unknown AZURE_CLOUD_NAME '{cloud_name}'. "
-            f"Valid values: {valid_clouds}"
-        )
+        raise ValueError(f"Unknown AZURE_CLOUD_NAME '{cloud_name}'. Valid values: {valid_clouds}")
 
     return _CLOUD_MAP[cloud_name]

--- a/src/mcp_server_azure_architect/audit.py
+++ b/src/mcp_server_azure_architect/audit.py
@@ -183,11 +183,13 @@ def setup_audit_logging() -> None:
     _AUDIT_LOGGER.addHandler(handler)
 
     _AUDIT_LOGGER.info(
-        json.dumps({
-            "event": "audit_logging_initialized",
-            "log_dir": str(log_dir),
-            "log_file": str(log_file),
-        })
+        json.dumps(
+            {
+                "event": "audit_logging_initialized",
+                "log_dir": str(log_dir),
+                "log_file": str(log_file),
+            }
+        )
     )
 
 
@@ -214,6 +216,7 @@ def audit_log_tool(func: Callable[P, R]) -> Callable[P, R]:
     Returns:
         Wrapped function with audit logging.
     """
+
     @functools.wraps(func)
     def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         logger = get_audit_logger()
@@ -229,12 +232,14 @@ def audit_log_tool(func: Callable[P, R]) -> Callable[P, R]:
 
         # Log invocation (caller identity not available from MCP context)
         logger.info(
-            json.dumps({
-                "event": "tool_invocation",
-                "tool": tool_name,
-                "params": redacted_params,
-                "caller": "unknown",  # MCP protocol does not surface caller identity
-            })
+            json.dumps(
+                {
+                    "event": "tool_invocation",
+                    "tool": tool_name,
+                    "params": redacted_params,
+                    "caller": "unknown",  # MCP protocol does not surface caller identity
+                }
+            )
         )
 
         try:
@@ -243,24 +248,28 @@ def audit_log_tool(func: Callable[P, R]) -> Callable[P, R]:
             # Log result summary (not full result to avoid leaking sensitive data)
             result_summary = _summarize_result(result)
             logger.info(
-                json.dumps({
-                    "event": "tool_result",
-                    "tool": tool_name,
-                    "status": "success",
-                    "summary": result_summary,
-                })
+                json.dumps(
+                    {
+                        "event": "tool_result",
+                        "tool": tool_name,
+                        "status": "success",
+                        "summary": result_summary,
+                    }
+                )
             )
 
             return result
         except Exception as e:
             # Log error
             logger.error(
-                json.dumps({
-                    "event": "tool_error",
-                    "tool": tool_name,
-                    "error_type": type(e).__name__,
-                    "error_message": str(e),
-                })
+                json.dumps(
+                    {
+                        "event": "tool_error",
+                        "tool": tool_name,
+                        "error_type": type(e).__name__,
+                        "error_message": str(e),
+                    }
+                )
             )
             raise
 
@@ -279,12 +288,14 @@ def audit_log_tool(func: Callable[P, R]) -> Callable[P, R]:
 
         # Log invocation
         logger.info(
-            json.dumps({
-                "event": "tool_invocation",
-                "tool": tool_name,
-                "params": redacted_params,
-                "caller": "unknown",
-            })
+            json.dumps(
+                {
+                    "event": "tool_invocation",
+                    "tool": tool_name,
+                    "params": redacted_params,
+                    "caller": "unknown",
+                }
+            )
         )
 
         try:
@@ -293,24 +304,28 @@ def audit_log_tool(func: Callable[P, R]) -> Callable[P, R]:
             # Log result summary
             result_summary = _summarize_result(result)
             logger.info(
-                json.dumps({
-                    "event": "tool_result",
-                    "tool": tool_name,
-                    "status": "success",
-                    "summary": result_summary,
-                })
+                json.dumps(
+                    {
+                        "event": "tool_result",
+                        "tool": tool_name,
+                        "status": "success",
+                        "summary": result_summary,
+                    }
+                )
             )
 
             return result  # type: ignore[no-any-return]
         except Exception as e:
             # Log error
             logger.error(
-                json.dumps({
-                    "event": "tool_error",
-                    "tool": tool_name,
-                    "error_type": type(e).__name__,
-                    "error_message": str(e),
-                })
+                json.dumps(
+                    {
+                        "event": "tool_error",
+                        "tool": tool_name,
+                        "error_type": type(e).__name__,
+                        "error_message": str(e),
+                    }
+                )
             )
             raise
 

--- a/src/mcp_server_azure_architect/azure_client.py
+++ b/src/mcp_server_azure_architect/azure_client.py
@@ -117,8 +117,6 @@ def validate_caller_scope(subscription_id: str, credential: DefaultAzureCredenti
 
     if not is_valid:
         scrubbed_id = scrub_subscription_id(subscription_id)
-        logger.warning(
-            f"Subscription ID validation failed: {scrubbed_id} is not in caller's scope"
-        )
+        logger.warning(f"Subscription ID validation failed: {scrubbed_id} is not in caller's scope")
 
     return is_valid

--- a/src/mcp_server_azure_architect/pricing.py
+++ b/src/mcp_server_azure_architect/pricing.py
@@ -521,7 +521,7 @@ def pricing_estimate_workload(spec: WorkloadSpec) -> dict[str, Any]:
         items = result["items"]
         if not items:
             warnings.append(
-                f"Storage SKU '{storage_item.sku}' not found in region " f"'{storage_region}'."
+                f"Storage SKU '{storage_item.sku}' not found in region '{storage_region}'."
             )
             continue
 
@@ -535,7 +535,7 @@ def pricing_estimate_workload(spec: WorkloadSpec) -> dict[str, Any]:
 
         if storage_cheapest is None:
             warnings.append(
-                f"Storage SKU '{storage_item.sku}' has no valid unit_price in API " f"response."
+                f"Storage SKU '{storage_item.sku}' has no valid unit_price in API response."
             )
             continue
 

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -169,6 +169,7 @@ def test_setup_audit_logging_creates_directory(tmp_path: Path) -> None:
     with patch.dict(os.environ, {"MCP_AZURE_ARCHITECT_LOG_DIR": str(log_dir)}):
         # Reset global logger
         import mcp_server_azure_architect.audit
+
         mcp_server_azure_architect.audit._AUDIT_LOGGER = None
 
         setup_audit_logging()
@@ -183,6 +184,7 @@ def test_setup_audit_logging_respects_env_var(tmp_path: Path) -> None:
 
     with patch.dict(os.environ, {"MCP_AZURE_ARCHITECT_LOG_DIR": str(custom_log_dir)}):
         import mcp_server_azure_architect.audit
+
         mcp_server_azure_architect.audit._AUDIT_LOGGER = None
 
         setup_audit_logging()

--- a/tests/test_azure_client.py
+++ b/tests/test_azure_client.py
@@ -52,9 +52,7 @@ def test_validate_caller_scope_accepts_valid_subscription() -> None:
     mock_sub2 = Mock()
     mock_sub2.subscription_id = "valid-sub-2"
 
-    with patch(
-        "azure.mgmt.subscription.SubscriptionClient"
-    ) as mock_client_class:
+    with patch("azure.mgmt.subscription.SubscriptionClient") as mock_client_class:
         mock_client = Mock()
         mock_client.subscriptions.list.return_value = [mock_sub1, mock_sub2]
         mock_client_class.return_value = mock_client
@@ -78,9 +76,7 @@ def test_validate_caller_scope_rejects_invalid_subscription() -> None:
     mock_sub1 = Mock()
     mock_sub1.subscription_id = "valid-sub-1"
 
-    with patch(
-        "azure.mgmt.subscription.SubscriptionClient"
-    ) as mock_client_class:
+    with patch("azure.mgmt.subscription.SubscriptionClient") as mock_client_class:
         mock_client = Mock()
         mock_client.subscriptions.list.return_value = [mock_sub1]
         mock_client_class.return_value = mock_client
@@ -100,9 +96,7 @@ def test_validate_caller_scope_caches_subscription_list() -> None:
     mock_sub1 = Mock()
     mock_sub1.subscription_id = "valid-sub-1"
 
-    with patch(
-        "azure.mgmt.subscription.SubscriptionClient"
-    ) as mock_client_class:
+    with patch("azure.mgmt.subscription.SubscriptionClient") as mock_client_class:
         mock_client = Mock()
         mock_client.subscriptions.list.return_value = [mock_sub1]
         mock_client_class.return_value = mock_client
@@ -126,9 +120,7 @@ def test_validate_caller_scope_propagates_arm_errors() -> None:
     """ARM API errors are propagated to the caller."""
     mock_credential = Mock()
 
-    with patch(
-        "azure.mgmt.subscription.SubscriptionClient"
-    ) as mock_client_class:
+    with patch("azure.mgmt.subscription.SubscriptionClient") as mock_client_class:
         mock_client = Mock()
         mock_client.subscriptions.list.side_effect = Exception("ARM API unavailable")
         mock_client_class.return_value = mock_client
@@ -152,9 +144,7 @@ def test_validate_caller_scope_handles_none_subscription_ids() -> None:
     mock_sub2 = Mock()
     mock_sub2.subscription_id = None  # ARM can return subscriptions with no ID
 
-    with patch(
-        "azure.mgmt.subscription.SubscriptionClient"
-    ) as mock_client_class:
+    with patch("azure.mgmt.subscription.SubscriptionClient") as mock_client_class:
         mock_client = Mock()
         mock_client.subscriptions.list.return_value = [mock_sub1, mock_sub2]
         mock_client_class.return_value = mock_client

--- a/tests/test_check_readonly.py
+++ b/tests/test_check_readonly.py
@@ -102,9 +102,7 @@ results = client.query("Resources | where type =~ 'Microsoft.Compute/virtualMach
         violations = scan_file(test_file)
         assert len(violations) == 0
 
-    def test_readonly_allow_comment_suppresses_violation(
-        self, tmp_path: Path
-    ) -> None:
+    def test_readonly_allow_comment_suppresses_violation(self, tmp_path: Path) -> None:
         """Verify that readonly-allow: comment suppresses violations."""
         code = """
 # readonly-allow: test fixture for demonstrating allow syntax

--- a/tests/test_clouds.py
+++ b/tests/test_clouds.py
@@ -67,9 +67,7 @@ class TestGetCloudConfig:
         assert config.arm_endpoint == "https://management.microsoftazure.de"
         assert config.arm_scope == "https://management.microsoftazure.de/.default"
 
-    def test_unknown_cloud_raises_value_error(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_unknown_cloud_raises_value_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Unknown AZURE_CLOUD_NAME should raise ValueError with valid options."""
         monkeypatch.setenv("AZURE_CLOUD_NAME", "InvalidCloud")
         with pytest.raises(ValueError, match="Unknown AZURE_CLOUD_NAME 'InvalidCloud'"):

--- a/tests/test_cold_start.py
+++ b/tests/test_cold_start.py
@@ -99,6 +99,5 @@ def test_httpx_fastmcp_owned_note() -> None:
     )
     assert result.returncode == 0, f"Import failed: {result.stderr}"
     assert "PASS" in result.stdout, (
-        "httpx is expected to be imported by FastMCP at server startup. "
-        "See issue #68 for context."
+        "httpx is expected to be imported by FastMCP at server startup. See issue #68 for context."
     )

--- a/tests/test_install_kit.py
+++ b/tests/test_install_kit.py
@@ -22,8 +22,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 import install_kit  # noqa: E402, I001
 
 
-
-
 def test_check_python_version() -> None:
     """Test Python version check returns correct status."""
     ok, msg = install_kit.check_python_version()
@@ -78,7 +76,14 @@ def test_get_config_path_claude_desktop(tmp_path: Path, monkeypatch: pytest.Monk
 
     with patch("platform.system", return_value="Darwin"):
         path = install_kit.get_config_path("claude-desktop")
-        assert path == tmp_path / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+        assert (
+            path
+            == tmp_path
+            / "Library"
+            / "Application Support"
+            / "Claude"
+            / "claude_desktop_config.json"
+        )
 
     with patch("platform.system", return_value="Linux"):
         path = install_kit.get_config_path("claude-desktop")
@@ -103,10 +108,7 @@ def test_load_existing_config_missing(tmp_path: Path) -> None:
     """Test loading config when file doesn't exist returns empty template."""
     config_path = tmp_path / "missing.json"
     config = install_kit.load_existing_config(config_path)
-    assert config == {
-        "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {}
-    }
+    assert config == {"$schema": "https://aka.ms/mcp-config-schema", "mcpServers": {}}
 
 
 def test_load_existing_config_valid(tmp_path: Path) -> None:
@@ -114,9 +116,7 @@ def test_load_existing_config_valid(tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
     existing = {
         "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {
-            "my-server": {"command": "npx", "args": ["-y", "my-server"]}
-        }
+        "mcpServers": {"my-server": {"command": "npx", "args": ["-y", "my-server"]}},
     }
     config_path.write_text(json.dumps(existing), encoding="utf-8")
 
@@ -142,15 +142,11 @@ def test_merge_configs_no_collision() -> None:
     """Test merging configs when no server name collision."""
     existing = {
         "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {
-            "existing-server": {"command": "existing"}
-        }
+        "mcpServers": {"existing-server": {"command": "existing"}},
     }
     curated = {
         "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {
-            "new-server": {"command": "new"}
-        }
+        "mcpServers": {"new-server": {"command": "new"}},
     }
 
     merged = install_kit.merge_configs(existing, curated, interactive=False)
@@ -164,15 +160,11 @@ def test_merge_configs_collision_skip() -> None:
     """Test merging configs with collision in non-interactive mode skips."""
     existing = {
         "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {
-            "shared-server": {"command": "existing"}
-        }
+        "mcpServers": {"shared-server": {"command": "existing"}},
     }
     curated = {
         "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {
-            "shared-server": {"command": "curated"}
-        }
+        "mcpServers": {"shared-server": {"command": "curated"}},
     }
 
     merged = install_kit.merge_configs(existing, curated, interactive=False)
@@ -184,15 +176,11 @@ def test_merge_configs_collision_overwrite_yes() -> None:
     """Test merging configs with collision and user chooses overwrite."""
     existing = {
         "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {
-            "shared-server": {"command": "existing"}
-        }
+        "mcpServers": {"shared-server": {"command": "existing"}},
     }
     curated = {
         "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {
-            "shared-server": {"command": "curated"}
-        }
+        "mcpServers": {"shared-server": {"command": "curated"}},
     }
 
     with patch("builtins.input", return_value="y"):
@@ -205,15 +193,11 @@ def test_merge_configs_collision_overwrite_no() -> None:
     """Test merging configs with collision and user chooses keep existing."""
     existing = {
         "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {
-            "shared-server": {"command": "existing"}
-        }
+        "mcpServers": {"shared-server": {"command": "existing"}},
     }
     curated = {
         "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {
-            "shared-server": {"command": "curated"}
-        }
+        "mcpServers": {"shared-server": {"command": "curated"}},
     }
 
     with patch("builtins.input", return_value="n"):
@@ -239,7 +223,7 @@ def test_write_config_actually_writes(tmp_path: Path) -> None:
     config_path = tmp_path / "test.json"
     config = {
         "$schema": "https://aka.ms/mcp-config-schema",
-        "mcpServers": {"test": {"command": "test"}}
+        "mcpServers": {"test": {"command": "test"}},
     }
 
     install_kit.write_config(config_path, config, dry_run=False)
@@ -297,6 +281,8 @@ def test_detect_clients_none(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_detect_clients_copilot_cli() -> None:
     """Test client detection finds Copilot CLI."""
-    with patch("shutil.which", side_effect=lambda cmd: "/usr/bin/copilot" if cmd == "copilot" else None):
+    with patch(
+        "shutil.which", side_effect=lambda cmd: "/usr/bin/copilot" if cmd == "copilot" else None
+    ):
         detected = install_kit.detect_clients()
         assert "copilot-cli" in detected

--- a/tests/test_log_permissions.py
+++ b/tests/test_log_permissions.py
@@ -46,7 +46,9 @@ def test_set_file_permissions_0600_windows(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="POSIX-only test")
-def test_check_directory_permissions_warns_on_permissive(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_check_directory_permissions_warns_on_permissive(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that warning is logged for permissive directory permissions."""
     test_dir = tmp_path / "test_dir"
     test_dir.mkdir()
@@ -61,7 +63,9 @@ def test_check_directory_permissions_warns_on_permissive(tmp_path: Path, caplog:
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="POSIX-only test")
-def test_check_directory_permissions_no_warn_on_0700(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_check_directory_permissions_no_warn_on_0700(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test that no warning is logged for secure directory permissions."""
     test_dir = tmp_path / "test_dir"
     test_dir.mkdir()
@@ -83,6 +87,7 @@ def test_setup_audit_logging_creates_secure_directory(tmp_path: Path) -> None:
     with patch.dict(os.environ, {"MCP_AZURE_ARCHITECT_LOG_DIR": str(log_dir)}):
         # Reset global logger
         import mcp_server_azure_architect.audit
+
         mcp_server_azure_architect.audit._AUDIT_LOGGER = None
 
         setup_audit_logging()
@@ -102,6 +107,7 @@ def test_setup_audit_logging_creates_secure_file(tmp_path: Path) -> None:
     with patch.dict(os.environ, {"MCP_AZURE_ARCHITECT_LOG_DIR": str(log_dir)}):
         # Reset global logger
         import mcp_server_azure_architect.audit
+
         mcp_server_azure_architect.audit._AUDIT_LOGGER = None
 
         setup_audit_logging()
@@ -121,6 +127,7 @@ def test_setup_audit_logging_windows_smoke(tmp_path: Path) -> None:
     with patch.dict(os.environ, {"MCP_AZURE_ARCHITECT_LOG_DIR": str(log_dir)}):
         # Reset global logger
         import mcp_server_azure_architect.audit
+
         mcp_server_azure_architect.audit._AUDIT_LOGGER = None
 
         setup_audit_logging()

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -116,9 +116,7 @@ def test_lookup_sku_reservation_term_in_filter() -> None:
         )
 
     with _install_mock_transport(handler):
-        result = pricing.pricing_lookup_sku(
-            sku="Standard_D2s_v5", region="westeurope", term="1yr"
-        )
+        result = pricing.pricing_lookup_sku(sku="Standard_D2s_v5", region="westeurope", term="1yr")
 
     assert "priceType eq 'Reservation'" in captured["filter"]
     assert "reservationTerm eq '1 Year'" in captured["filter"]
@@ -146,9 +144,7 @@ def test_lookup_sku_pagination() -> None:
         )
 
     with _install_mock_transport(handler):
-        result = pricing.pricing_lookup_sku(
-            sku="Standard_D2s_v5", region="westeurope"
-        )
+        result = pricing.pricing_lookup_sku(sku="Standard_D2s_v5", region="westeurope")
 
     assert len(calls) == 2
     assert "page=2" in calls[1]
@@ -175,9 +171,7 @@ def test_lookup_sku_pagination_capped() -> None:
         )
 
     with _install_mock_transport(handler):
-        result = pricing.pricing_lookup_sku(
-            sku="Standard_D2s_v5", region="westeurope"
-        )
+        result = pricing.pricing_lookup_sku(sku="Standard_D2s_v5", region="westeurope")
 
     assert call_count == pricing._MAX_PAGES
     assert result["item_count"] == pricing._MAX_PAGES
@@ -190,9 +184,7 @@ def test_lookup_sku_caching() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         nonlocal call_count
         call_count += 1
-        return httpx.Response(
-            200, json={"Items": [_make_item()], "NextPageLink": None}
-        )
+        return httpx.Response(200, json={"Items": [_make_item()], "NextPageLink": None})
 
     with _install_mock_transport(handler):
         pricing.pricing_lookup_sku(sku="Standard_D2s_v5", region="westeurope")
@@ -208,17 +200,11 @@ def test_lookup_sku_cache_currency_isolation() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         nonlocal call_count
         call_count += 1
-        return httpx.Response(
-            200, json={"Items": [_make_item()], "NextPageLink": None}
-        )
+        return httpx.Response(200, json={"Items": [_make_item()], "NextPageLink": None})
 
     with _install_mock_transport(handler):
-        pricing.pricing_lookup_sku(
-            sku="Standard_D2s_v5", region="westeurope", currency="USD"
-        )
-        pricing.pricing_lookup_sku(
-            sku="Standard_D2s_v5", region="westeurope", currency="EUR"
-        )
+        pricing.pricing_lookup_sku(sku="Standard_D2s_v5", region="westeurope", currency="USD")
+        pricing.pricing_lookup_sku(sku="Standard_D2s_v5", region="westeurope", currency="EUR")
 
     assert call_count == 2
 
@@ -230,9 +216,7 @@ def test_lookup_sku_empty_results() -> None:
         return httpx.Response(200, json={"Items": [], "NextPageLink": None})
 
     with _install_mock_transport(handler):
-        result = pricing.pricing_lookup_sku(
-            sku="Standard_NotARealSku", region="westeurope"
-        )
+        result = pricing.pricing_lookup_sku(sku="Standard_NotARealSku", region="westeurope")
 
     assert result["items"] == []
     assert result["item_count"] == 0
@@ -241,7 +225,9 @@ def test_lookup_sku_empty_results() -> None:
 def test_lookup_sku_invalid_term_raises() -> None:
     with pytest.raises(ValueError, match="Unknown term"):
         pricing.pricing_lookup_sku(
-            sku="Standard_D2s_v5", region="westeurope", term="lifetime"  # type: ignore[arg-type]
+            sku="Standard_D2s_v5",
+            region="westeurope",
+            term="lifetime",  # type: ignore[arg-type]
         )
 
 
@@ -266,14 +252,12 @@ def test_compare_skus_combines_results() -> None:
         if "D2s_v5" in sku_clause:
             return httpx.Response(
                 200,
-                json={"Items": [_make_item("Standard_D2s_v5", price=0.096)],
-                      "NextPageLink": None},
+                json={"Items": [_make_item("Standard_D2s_v5", price=0.096)], "NextPageLink": None},
             )
         if "D4s_v5" in sku_clause:
             return httpx.Response(
                 200,
-                json={"Items": [_make_item("Standard_D4s_v5", price=0.192)],
-                      "NextPageLink": None},
+                json={"Items": [_make_item("Standard_D4s_v5", price=0.192)], "NextPageLink": None},
             )
         return httpx.Response(200, json={"Items": [], "NextPageLink": None})
 
@@ -296,9 +280,7 @@ def test_compare_skus_marks_missing_sku() -> None:
         return httpx.Response(200, json={"Items": [], "NextPageLink": None})
 
     with _install_mock_transport(handler):
-        result = pricing.pricing_compare_skus(
-            skus=["Standard_NotReal"], region="westeurope"
-        )
+        result = pricing.pricing_compare_skus(skus=["Standard_NotReal"], region="westeurope")
 
     row = result["comparison"][0]
     assert row["found"] is False
@@ -366,9 +348,7 @@ def test_pricing_lookup_sku_via_server_tool() -> None:
     from mcp_server_azure_architect.server import pricing_lookup_sku as server_tool
 
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200, json={"Items": [_make_item()], "NextPageLink": None}
-        )
+        return httpx.Response(200, json={"Items": [_make_item()], "NextPageLink": None})
 
     with _install_mock_transport(handler):
         result = server_tool(sku="Standard_D2s_v5", region="westeurope")

--- a/tests/test_refresh_alz_snapshot.py
+++ b/tests/test_refresh_alz_snapshot.py
@@ -36,7 +36,9 @@ def mock_manifest() -> dict:
                 "subset": {
                     "source_file": "queries/alz_all_queries.json",
                     "checklist_ids": ["54f0d8b1-22a3-4c0d-8ce2-58b9e086c93a"],
-                    "files": ["data/alz-queries/checklist/54f0d8b1-22a3-4c0d-8ce2-58b9e086c93a.kql"],
+                    "files": [
+                        "data/alz-queries/checklist/54f0d8b1-22a3-4c0d-8ce2-58b9e086c93a.kql"
+                    ],
                 },
                 "file_count": 1,
             },
@@ -155,18 +157,22 @@ def test_extract_queries_from_checklist_repo(tmp_path: Path) -> None:
 
     # Mock alz_all_queries.json
     source_json = queries_dir / "alz_all_queries.json"
-    source_json.write_text(json.dumps({
-        "items": [
+    source_json.write_text(
+        json.dumps(
             {
-                "id": "test-checklist-1",
-                "graph": "resources | where type =~ 'microsoft.test'",
-            },
-            {
-                "id": "test-checklist-2",
-                "graph": "resources | where name =~ 'testname'",
-            },
-        ]
-    }))
+                "items": [
+                    {
+                        "id": "test-checklist-1",
+                        "graph": "resources | where type =~ 'microsoft.test'",
+                    },
+                    {
+                        "id": "test-checklist-2",
+                        "graph": "resources | where name =~ 'testname'",
+                    },
+                ]
+            }
+        )
+    )
 
     dest_dir = tmp_path / "output"
     dest_dir.mkdir()
@@ -193,24 +199,25 @@ def test_extract_queries_from_graph_repo(tmp_path: Path) -> None:
 
     # Mock alz_additional_queries.json with realistic upstream schema
     source_json = queries_dir / "alz_additional_queries.json"
-    source_json.write_text(json.dumps({
-        "metadata": {
-            "name": "ALZ Additional Graph Queries",
-            "version": "1.0.0"
-        },
-        "queries": [
+    source_json.write_text(
+        json.dumps(
             {
-                "guid": "test-graph-1",
-                "graph": "graph | where type =~ 'test'",
-                "queryable": True,
-            },
-            {
-                "guid": "test-graph-2",
-                "graph": "graph | where name =~ 'nonqueryable'",
-                "queryable": False,
+                "metadata": {"name": "ALZ Additional Graph Queries", "version": "1.0.0"},
+                "queries": [
+                    {
+                        "guid": "test-graph-1",
+                        "graph": "graph | where type =~ 'test'",
+                        "queryable": True,
+                    },
+                    {
+                        "guid": "test-graph-2",
+                        "graph": "graph | where name =~ 'nonqueryable'",
+                        "queryable": False,
+                    },
+                ],
             }
-        ]
-    }))
+        )
+    )
 
     dest_dir = tmp_path / "output"
     dest_dir.mkdir()
@@ -276,15 +283,19 @@ def test_extract_queries_schema_mismatch_graph(tmp_path: Path) -> None:
 
     # Mock upstream with wrong top-level key
     source_json = queries_dir / "alz_additional_queries.json"
-    source_json.write_text(json.dumps({
-        "items": [  # Wrong key - should be "queries"
+    source_json.write_text(
+        json.dumps(
             {
-                "guid": "test-id",
-                "graph": "resources | where type =~ 'test'",
-                "queryable": True,
+                "items": [  # Wrong key - should be "queries"
+                    {
+                        "guid": "test-id",
+                        "graph": "resources | where type =~ 'test'",
+                        "queryable": True,
+                    }
+                ]
             }
-        ]
-    }))
+        )
+    )
 
     dest_dir = tmp_path / "output"
     dest_dir.mkdir()
@@ -303,15 +314,19 @@ def test_extract_queries_schema_mismatch_checklist(tmp_path: Path) -> None:
 
     # Mock upstream with wrong top-level key
     source_json = queries_dir / "alz_all_queries.json"
-    source_json.write_text(json.dumps({
-        "queries": [  # Wrong key - should be "items"
+    source_json.write_text(
+        json.dumps(
             {
-                "id": "test-id",
-                "graph": "resources | where type =~ 'test'",
-                "queryable": True,
+                "queries": [  # Wrong key - should be "items"
+                    {
+                        "id": "test-id",
+                        "graph": "resources | where type =~ 'test'",
+                        "queryable": True,
+                    }
+                ]
             }
-        ]
-    }))
+        )
+    )
 
     dest_dir = tmp_path / "output"
     dest_dir.mkdir()

--- a/tests/test_server_annotations.py
+++ b/tests/test_server_annotations.py
@@ -60,18 +60,14 @@ def test_tool_annotation_completeness() -> None:
 
         # Check all expected fields are not None
         assert tool.annotations.title is not None, f"Tool {tool.name} missing title"
-        assert (
-            tool.annotations.readOnlyHint is not None
-        ), f"Tool {tool.name} missing readOnlyHint"
-        assert (
-            tool.annotations.destructiveHint is not None
-        ), f"Tool {tool.name} missing destructiveHint"
-        assert (
-            tool.annotations.idempotentHint is not None
-        ), f"Tool {tool.name} missing idempotentHint"
-        assert (
-            tool.annotations.openWorldHint is not None
-        ), f"Tool {tool.name} missing openWorldHint"
+        assert tool.annotations.readOnlyHint is not None, f"Tool {tool.name} missing readOnlyHint"
+        assert tool.annotations.destructiveHint is not None, (
+            f"Tool {tool.name} missing destructiveHint"
+        )
+        assert tool.annotations.idempotentHint is not None, (
+            f"Tool {tool.name} missing idempotentHint"
+        )
+        assert tool.annotations.openWorldHint is not None, f"Tool {tool.name} missing openWorldHint"
 
 
 def test_expected_tool_titles() -> None:
@@ -118,12 +114,12 @@ def test_alz_and_pricing_tools_are_idempotent_and_open_world() -> None:
     for tool in tools:
         if tool.name in alz_and_pricing_tools:
             assert tool.annotations is not None
-            assert (
-                tool.annotations.idempotentHint is True
-            ), f"Tool {tool.name} should have idempotentHint=True"
-            assert (
-                tool.annotations.openWorldHint is True
-            ), f"Tool {tool.name} should have openWorldHint=True"
+            assert tool.annotations.idempotentHint is True, (
+                f"Tool {tool.name} should have idempotentHint=True"
+            )
+            assert tool.annotations.openWorldHint is True, (
+                f"Tool {tool.name} should have openWorldHint=True"
+            )
 
 
 def test_health_check_is_closed_world() -> None:
@@ -133,9 +129,9 @@ def test_health_check_is_closed_world() -> None:
 
     assert health_tool is not None, "health_check tool not found"
     assert health_tool.annotations is not None
-    assert (
-        health_tool.annotations.openWorldHint is False
-    ), "health_check should have openWorldHint=False (no external calls)"
-    assert (
-        health_tool.annotations.idempotentHint is True
-    ), "health_check should have idempotentHint=True (always returns same result)"
+    assert health_tool.annotations.openWorldHint is False, (
+        "health_check should have openWorldHint=False (no external calls)"
+    )
+    assert health_tool.annotations.idempotentHint is True, (
+        "health_check should have idempotentHint=True (always returns same result)"
+    )

--- a/tests/test_verify_query_integrity.py
+++ b/tests/test_verify_query_integrity.py
@@ -54,11 +54,9 @@ def test_verify_integrity_happy_path(tmp_path: Path) -> None:
                     "source_file": "queries/test.json",
                     "checklist_ids": ["test-id"],
                     "files": ["data/alz-queries/checklist/test-query.kql"],
-                    "sha256": {
-                        "data/alz-queries/checklist/test-query.kql": expected_hash
-                    }
+                    "sha256": {"data/alz-queries/checklist/test-query.kql": expected_hash},
                 },
-                "file_count": 1
+                "file_count": 1,
             }
         ]
     }
@@ -97,9 +95,9 @@ def test_verify_integrity_tampered_file(tmp_path: Path) -> None:
                     "files": ["data/alz-queries/checklist/test-query.kql"],
                     "sha256": {
                         "data/alz-queries/checklist/test-query.kql": "0" * 64  # Wrong hash
-                    }
+                    },
                 },
-                "file_count": 1
+                "file_count": 1,
             }
         ]
     }
@@ -131,11 +129,9 @@ def test_verify_integrity_missing_file(tmp_path: Path) -> None:
                     "source_file": "queries/test.json",
                     "checklist_ids": ["test-id"],
                     "files": ["data/alz-queries/checklist/test-query.kql"],
-                    "sha256": {
-                        "data/alz-queries/checklist/test-query.kql": "a" * 64
-                    }
+                    "sha256": {"data/alz-queries/checklist/test-query.kql": "a" * 64},
                 },
-                "file_count": 1
+                "file_count": 1,
             }
         ]
     }
@@ -174,7 +170,7 @@ def test_verify_integrity_missing_hash(tmp_path: Path) -> None:
                     "files": ["data/alz-queries/checklist/test-query.kql"],
                     # No sha256 field
                 },
-                "file_count": 1
+                "file_count": 1,
             }
         ]
     }
@@ -212,7 +208,7 @@ def test_update_hashes(tmp_path: Path) -> None:
                     "checklist_ids": ["test-id"],
                     "files": ["data/alz-queries/checklist/test-query.kql"],
                 },
-                "file_count": 1
+                "file_count": 1,
             }
         ]
     }
@@ -258,7 +254,7 @@ def test_update_hashes_missing_file(tmp_path: Path) -> None:
                     "checklist_ids": ["test-id"],
                     "files": ["data/alz-queries/checklist/missing.kql"],
                 },
-                "file_count": 1
+                "file_count": 1,
             }
         ]
     }
@@ -285,9 +281,9 @@ def test_generate_markdown_manifest(tmp_path: Path) -> None:
                     "source_file": "queries/test.json",
                     "checklist_ids": ["id1", "id2"],
                     "files": ["data/alz-queries/checklist/id1.kql"],
-                    "sha256": {"data/alz-queries/checklist/id1.kql": "a" * 64}
+                    "sha256": {"data/alz-queries/checklist/id1.kql": "a" * 64},
                 },
-                "file_count": 2
+                "file_count": 2,
             }
         ]
     }


### PR DESCRIPTION
## Summary

This PR closes #117 by adding a ruff format --check gate to CI and bringing the codebase to compliance.

## Implementation

Three commits for clean reviewability:

**Commit 1 (7825af7): chore(format): ruff format pass (19 files)**
- Applied ruff format to 19 files with latent drift on main
- No logic changes, formatting only

**Commit 2 (2191fcd): chore(ci): pin ruff to 0.15.12 and add ruff format --check gate**
- Pinned ruff in pyproject.toml: changed \uff>=0.3.0\ to \uff==0.15.12\
- Added new step \uff format --check .\ in the existing CI test job, immediately after the ruff check step
- Updated CONTRIBUTING.md to include ruff format --check in the local validation commands
- Added CHANGELOG.md entry under [Unreleased] > Automation

## CI Placement Choice

**Added as a NEW STEP inside the existing \	est\ job** (after the \uff check .\ step).

This approach inherits the already-required \CI/test (ubuntu-latest, 3.x)\ check and does NOT require a branch protection update post-merge. The format check runs on every PR as part of the existing required check.

## Branch Protection Update Needed Post-Merge

**NO** — the format check is embedded in the existing required \	est\ job.

## Validation

All validation gates pass locally:
- \uff check .\ ✅
- \uff format --check .\ ✅
- \mypy src\ ✅
- \pytest -q\ ✅ (178 passed, 6 skipped, 1 warning)

Closes #117