### PR TITLE
chore(ci): breaking-change detector on refresh PRs (closes #102)

### DIFF
--- a/.github/workflows/breaking-change-detector.yml
+++ b/.github/workflows/breaking-change-detector.yml
@@ -1,0 +1,87 @@
+name: Breaking-change detector
+
+on:
+  pull_request:
+    paths:
+      - "data/alz-queries/**"
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code with full history
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Check for override label
+        id: check_label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep -q "^breaking-change-approved$"; then
+            echo "has_override=true" >> $GITHUB_OUTPUT
+            echo "PR has breaking-change-approved label - skipping check"
+          else
+            echo "has_override=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run breaking-change detector
+        id: detect
+        if: steps.check_label.outputs.has_override != 'true'
+        run: |
+          python scripts/check_breaking_changes.py \
+            --base-ref origin/${{ github.base_ref }} \
+            --head-ref HEAD \
+            --output markdown > report.md
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
+        continue-on-error: true
+
+      - name: Find existing bot comment
+        id: find_comment
+        if: steps.check_label.outputs.has_override != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          comment_id=$(gh pr view ${{ github.event.pull_request.number }} --json comments \
+            --jq '.comments[] | select(.author.login == "github-actions" and (.body | startswith("## ALZ Snapshot Breaking-Change Report"))) | .id' \
+            | head -n 1)
+          if [ -n "$comment_id" ]; then
+            echo "comment_id=$comment_id" >> $GITHUB_OUTPUT
+          else
+            echo "comment_id=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post or update breaking change report
+        if: steps.check_label.outputs.has_override != 'true' && steps.detect.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "${{ steps.find_comment.outputs.comment_id }}" ]; then
+            gh pr comment ${{ github.event.pull_request.number }} --edit-last --body-file report.md
+          else
+            gh pr comment ${{ github.event.pull_request.number }} --body-file report.md
+          fi
+
+      - name: Post clean status
+        if: steps.check_label.outputs.has_override != 'true' && steps.detect.outputs.exit_code == '0' && steps.find_comment.outputs.comment_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body "$(cat report.md)"
+
+      - name: Fail job on breaking changes
+        if: steps.check_label.outputs.has_override != 'true' && steps.detect.outputs.exit_code == '1'
+        run: |
+          echo "Breaking changes detected. Review the comment on the PR."
+          exit 1

--- a/.github/workflows/breaking-change-detector.yml
+++ b/.github/workflows/breaking-change-detector.yml
@@ -40,12 +40,14 @@ jobs:
         id: detect
         if: steps.check_label.outputs.has_override != 'true'
         run: |
-          python scripts/check_breaking_changes.py \
-            --base-ref origin/${{ github.base_ref }} \
-            --head-ref HEAD \
-            --output markdown > report.md
-          echo "exit_code=$?" >> $GITHUB_OUTPUT
-        continue-on-error: true
+          if python scripts/check_breaking_changes.py \
+               --base-ref origin/${{ github.base_ref }} \
+               --head-ref HEAD \
+               --output markdown > report.md; then
+            echo "exit_code=0" >> $GITHUB_OUTPUT
+          else
+            echo "exit_code=$?" >> $GITHUB_OUTPUT
+          fi
 
       - name: Find existing bot comment
         id: find_comment
@@ -54,7 +56,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           comment_id=$(gh pr view ${{ github.event.pull_request.number }} --json comments \
-            --jq '.comments[] | select(.author.login == "github-actions" and (.body | startswith("## ALZ Snapshot Breaking-Change Report"))) | .id' \
+            --jq '.comments[] | select(.author.login == "github-actions[bot]" and (.body | startswith("## ALZ Snapshot Breaking-Change Report"))) | .id' \
             | head -n 1)
           if [ -n "$comment_id" ]; then
             echo "comment_id=$comment_id" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Automation
 
 - **CI now enforces ruff format consistency.** New required check `ruff format --check .` runs on every PR after the lint step. Prevents format drift. Ruff version pinned to `0.15.12` in `pyproject.toml` to ensure reproducible formatting across local and CI environments. (Closes #117)
+- Added breaking-change detector for ALZ refresh PRs (closes #102). Use `breaking-change-approved` label to override.
 
 ### Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,8 @@ Any hard-coded Azure identifier (policy ID, initiative ID, role definition ID, r
 
 The vendored ALZ checklist snapshot lives in `data/alz-queries/` with a `MANIFEST.md` that records the source repo and pinned commit SHA.
 
+**Breaking-change detection:** Automated refresh PRs (from `.github/workflows/refresh-alz-snapshot.yml`) trigger a breaking-change detector (`.github/workflows/breaking-change-detector.yml`) that flags when the first table reference token in a `.kql` file changes. If breaking changes are intentional (e.g., upstream schema updates), apply the `breaking-change-approved` label to the PR.
+
 ## Companion MCP servers
 
 The shipped `mcp-config.json` lists recommended companion servers. Adding a companion requires:

--- a/data/alz-queries/MANIFEST.md
+++ b/data/alz-queries/MANIFEST.md
@@ -38,3 +38,18 @@ Vendored snapshots are refreshed automatically on a **weekly cadence** (Monday 0
 - source_file: `queries/alz_additional_queries.json`
 - checklist_ids: `e8aa1e41-870d-4968-94c6-77be14f510ac, 667313b4-f566-44b5-b984-a859c773e7d2`
 - file_count: `2`
+
+## Breaking-change detection
+
+Refresh PRs are automatically checked for breaking changes via `.github/workflows/breaking-change-detector.yml`. The workflow detects when the first table reference token in a `.kql` file changes, which signals a schema surface change (e.g., `resources` to `securityresources`).
+
+**Breaking changes** (fail the check):
+- First table reference token changed (schema surface altered)
+- Query file removed
+
+**Non-breaking changes** (pass):
+- Header-only changes (updated commit SHA, timestamp)
+- Body changes with same first token (query logic refined)
+- New query files added
+
+**Override:** If a breaking change is intentional (e.g., upstream schema update), apply the `breaking-change-approved` label to the PR to bypass the check.

--- a/scripts/check_breaking_changes.py
+++ b/scripts/check_breaking_changes.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""KQL breaking-change detector for ALZ snapshot refresh PRs.
+
+Compares vendored .kql files between base-ref and head-ref. Flags breaking changes
+when the first table reference token changes (schema surface altered).
+
+Stdlib only. No external runtime dependencies.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class ChangeType(Enum):
+    """Change classification for a single .kql file."""
+
+    UNCHANGED = "unchanged"
+    FIRST_TOKEN_CHANGED = "first_token_changed"
+    REMOVED = "removed"
+    ADDED = "added"
+    HEADER_ONLY_CHANGED = "header_only_changed"
+    BODY_CHANGED_SAME_TOKEN = "body_changed_same_token"
+
+
+@dataclass
+class FileChange:
+    """Change record for a single .kql file."""
+
+    path: str
+    change_type: ChangeType
+    base_token: str | None
+    head_token: str | None
+    breaking: bool
+
+
+def extract_first_token(content: str) -> str | None:
+    """Extract the first identifier token from a .kql file.
+
+    Args:
+        content: Full .kql file content (headers + query)
+
+    Returns:
+        First identifier token on first non-comment line, or None if not found
+    """
+    for line in content.splitlines():
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("//"):
+            continue
+        match = re.match(r"([A-Za-z_][A-Za-z0-9_]*)", stripped)
+        if match:
+            return match.group(1)
+    return None
+
+
+def get_file_content(ref: str, path: str) -> str | None:
+    """Retrieve file content at a specific git ref.
+
+    Args:
+        ref: Git ref (e.g., "origin/main", "HEAD")
+        path: Relative file path from repo root
+
+    Returns:
+        File content as string, or None if file does not exist at ref
+    """
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{path}"],
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
+        return result.stdout
+    except subprocess.CalledProcessError:
+        return None
+
+
+def strip_header(content: str) -> str:
+    """Extract only the KQL query body (skip header comment lines).
+
+    Args:
+        content: Full .kql file content
+
+    Returns:
+        Query body (first non-comment line)
+    """
+    for line in content.splitlines():
+        stripped = line.lstrip()
+        if stripped and not stripped.startswith("//"):
+            return stripped
+    return ""
+
+
+def classify_change(path: str, base_content: str | None, head_content: str | None) -> FileChange:
+    """Classify change type for a single .kql file.
+
+    Args:
+        path: File path relative to repo root
+        base_content: File content at base-ref (None if file did not exist)
+        head_content: File content at head-ref (None if file removed)
+
+    Returns:
+        FileChange record with classification and breaking flag
+    """
+    if base_content is None and head_content is not None:
+        head_token = extract_first_token(head_content)
+        return FileChange(
+            path=path,
+            change_type=ChangeType.ADDED,
+            base_token=None,
+            head_token=head_token,
+            breaking=False,
+        )
+
+    if base_content is not None and head_content is None:
+        base_token = extract_first_token(base_content)
+        return FileChange(
+            path=path,
+            change_type=ChangeType.REMOVED,
+            base_token=base_token,
+            head_token=None,
+            breaking=True,
+        )
+
+    if base_content == head_content:
+        base_token = extract_first_token(base_content)
+        return FileChange(
+            path=path,
+            change_type=ChangeType.UNCHANGED,
+            base_token=base_token,
+            head_token=base_token,
+            breaking=False,
+        )
+
+    base_token = extract_first_token(base_content)
+    head_token = extract_first_token(head_content)
+
+    base_body = strip_header(base_content)
+    head_body = strip_header(head_content)
+
+    if base_body == head_body:
+        return FileChange(
+            path=path,
+            change_type=ChangeType.HEADER_ONLY_CHANGED,
+            base_token=base_token,
+            head_token=head_token,
+            breaking=False,
+        )
+
+    if base_token != head_token:
+        return FileChange(
+            path=path,
+            change_type=ChangeType.FIRST_TOKEN_CHANGED,
+            base_token=base_token,
+            head_token=head_token,
+            breaking=True,
+        )
+
+    return FileChange(
+        path=path,
+        change_type=ChangeType.BODY_CHANGED_SAME_TOKEN,
+        base_token=base_token,
+        head_token=head_token,
+        breaking=False,
+    )
+
+
+def collect_kql_files(data_dir: Path) -> list[str]:
+    """Find all .kql files under data_dir.
+
+    Args:
+        data_dir: Root directory to scan (e.g., data/alz-queries)
+
+    Returns:
+        List of relative file paths (relative to repo root)
+    """
+    files = []
+    for kql_file in data_dir.rglob("*.kql"):
+        files.append(str(kql_file).replace("\\", "/"))
+    return sorted(files)
+
+
+def analyze_changes(
+    base_ref: str, head_ref: str, data_dir: Path
+) -> tuple[list[FileChange], dict[str, int]]:
+    """Analyze all .kql files for breaking changes.
+
+    Args:
+        base_ref: Git ref for base (e.g., "origin/main")
+        head_ref: Git ref for head (e.g., "HEAD")
+        data_dir: Root directory for .kql files
+
+    Returns:
+        Tuple of (list of FileChange records, summary counts dict)
+    """
+    head_files = set(collect_kql_files(data_dir))
+
+    try:
+        result = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", base_ref],
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
+        base_all_files = set(result.stdout.splitlines())
+        base_files = {f for f in base_all_files if f.endswith(".kql") and data_dir.name in f}
+    except subprocess.CalledProcessError:
+        base_files = set()
+
+    all_files = head_files | base_files
+    changes = []
+
+    for file_path in sorted(all_files):
+        base_content = get_file_content(base_ref, file_path) if file_path in base_files else None
+        head_content = get_file_content(head_ref, file_path) if file_path in head_files else None
+        change = classify_change(file_path, base_content, head_content)
+        changes.append(change)
+
+    summary = {
+        "total": len(changes),
+        "breaking": sum(1 for c in changes if c.breaking),
+        "unchanged": sum(1 for c in changes if c.change_type == ChangeType.UNCHANGED),
+        "added": sum(1 for c in changes if c.change_type == ChangeType.ADDED),
+        "removed": sum(1 for c in changes if c.change_type == ChangeType.REMOVED),
+        "first_token_changed": sum(
+            1 for c in changes if c.change_type == ChangeType.FIRST_TOKEN_CHANGED
+        ),
+        "header_only_changed": sum(
+            1 for c in changes if c.change_type == ChangeType.HEADER_ONLY_CHANGED
+        ),
+        "body_changed_same_token": sum(
+            1 for c in changes if c.change_type == ChangeType.BODY_CHANGED_SAME_TOKEN
+        ),
+    }
+
+    return changes, summary
+
+
+def format_markdown(changes: list[FileChange], summary: dict[str, int]) -> str:
+    """Format breaking-change report as markdown.
+
+    Args:
+        changes: List of FileChange records
+        summary: Summary counts dict
+
+    Returns:
+        Markdown-formatted report
+    """
+    lines = ["## ALZ Snapshot Breaking-Change Report", ""]
+
+    if summary["breaking"] == 0:
+        lines.append("**No breaking changes detected.**")
+        lines.append("")
+        lines.append(f"- Total files analyzed: {summary['total']}")
+        lines.append(f"- Unchanged: {summary['unchanged']}")
+        lines.append(f"- Added: {summary['added']}")
+        lines.append(f"- Header-only changes: {summary['header_only_changed']}")
+        lines.append(f"- Body changes (same token): {summary['body_changed_same_token']}")
+        return "\n".join(lines)
+
+    lines.append(f"**{summary['breaking']} breaking change(s) detected.**")
+    lines.append("")
+    lines.append("### Summary")
+    lines.append("")
+    lines.append(f"- **Breaking changes**: {summary['breaking']}")
+    lines.append(f"  - First token changed: {summary['first_token_changed']}")
+    lines.append(f"  - Files removed: {summary['removed']}")
+    lines.append(f"- Total files analyzed: {summary['total']}")
+    lines.append(f"- Unchanged: {summary['unchanged']}")
+    lines.append(f"- Added: {summary['added']}")
+    lines.append(f"- Header-only changes: {summary['header_only_changed']}")
+    lines.append(f"- Body changes (same token): {summary['body_changed_same_token']}")
+    lines.append("")
+
+    breaking_changes = [c for c in changes if c.breaking]
+    if breaking_changes:
+        lines.append("### Breaking changes")
+        lines.append("")
+        lines.append("| File | Change Type | Base Token | Head Token |")
+        lines.append("|------|-------------|------------|------------|")
+        for change in breaking_changes:
+            base_token_str = change.base_token or "(none)"
+            head_token_str = change.head_token or "(none)"
+            lines.append(
+                f"| `{change.path}` | {change.change_type.value} | "
+                f"`{base_token_str}` | `{head_token_str}` |"
+            )
+        lines.append("")
+
+    non_breaking_changes = [
+        c
+        for c in changes
+        if not c.breaking
+        and c.change_type not in (ChangeType.UNCHANGED, ChangeType.HEADER_ONLY_CHANGED)
+    ]
+    if non_breaking_changes:
+        lines.append("### Non-breaking changes for review")
+        lines.append("")
+        lines.append("| File | Change Type | Token |")
+        lines.append("|------|-------------|-------|")
+        for change in non_breaking_changes:
+            token_str = change.head_token or "(none)"
+            lines.append(f"| `{change.path}` | {change.change_type.value} | `{token_str}` |")
+        lines.append("")
+
+    lines.append(
+        "**Action required**: Review the breaking changes above. "
+        "If these are legitimate schema updates, apply the `breaking-change-approved` "
+        "label to override this check."
+    )
+
+    return "\n".join(lines)
+
+
+def format_json(changes: list[FileChange], summary: dict[str, int]) -> str:
+    """Format breaking-change report as JSON.
+
+    Args:
+        changes: List of FileChange records
+        summary: Summary counts dict
+
+    Returns:
+        JSON-formatted report
+    """
+    data: dict[str, Any] = {
+        "summary": summary,
+        "breaking": summary["breaking"] > 0,
+        "changes": [
+            {
+                "path": c.path,
+                "change_type": c.change_type.value,
+                "base_token": c.base_token,
+                "head_token": c.head_token,
+                "breaking": c.breaking,
+            }
+            for c in changes
+        ],
+    }
+    return json.dumps(data, indent=2)
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="KQL breaking-change detector for ALZ snapshot refresh PRs"
+    )
+    parser.add_argument("--base-ref", required=True, help="Git ref for base (e.g., origin/main)")
+    parser.add_argument("--head-ref", default="HEAD", help="Git ref for head (default: HEAD)")
+    parser.add_argument(
+        "--output",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path("data/alz-queries"),
+        help="Root directory for .kql files (default: data/alz-queries)",
+    )
+    parser.add_argument(
+        "--no-fail",
+        action="store_true",
+        help="Exit with code 0 even if breaking changes detected",
+    )
+
+    args = parser.parse_args()
+
+    changes, summary = analyze_changes(args.base_ref, args.head_ref, args.data_dir)
+
+    if args.output == "markdown":
+        output = format_markdown(changes, summary)
+    else:
+        output = format_json(changes, summary)
+
+    print(output)
+
+    if summary["breaking"] > 0 and not args.no_fail:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_breaking_changes.py
+++ b/tests/test_check_breaking_changes.py
@@ -1,0 +1,363 @@
+"""Tests for check_breaking_changes.py script."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """Create a temporary git repository for testing."""
+    repo_dir = tmp_path / "test_repo"
+    repo_dir.mkdir()
+
+    subprocess.run(["git", "init"], cwd=repo_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+    )
+
+    return repo_dir
+
+
+def create_kql_file(repo_dir: Path, rel_path: str, content: str) -> None:
+    """Create a .kql file in the repo with the given content."""
+    full_path = repo_dir / rel_path
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.write_text(content, encoding="utf-8")
+
+
+def git_commit(repo_dir: Path, message: str) -> None:
+    """Add all changes and commit."""
+    subprocess.run(["git", "add", "-A"], cwd=repo_dir, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", message], cwd=repo_dir, check=True, capture_output=True)
+
+
+def run_detector(
+    repo_dir: Path, base_ref: str, head_ref: str = "HEAD", output: str = "markdown"
+) -> tuple[int, str]:
+    """Run the breaking-change detector script."""
+    result = subprocess.run(
+        [
+            "python",
+            str(Path(__file__).parent.parent / "scripts" / "check_breaking_changes.py"),
+            "--base-ref",
+            base_ref,
+            "--head-ref",
+            head_ref,
+            "--output",
+            output,
+            "--data-dir",
+            "data/alz-queries",
+        ],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    return result.returncode, result.stdout
+
+
+def test_unchanged_file(git_repo):
+    """Test that unchanged files are classified correctly."""
+    content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", content)
+    git_commit(git_repo, "Initial commit")
+
+    exit_code, output = run_detector(git_repo, "HEAD")
+    assert exit_code == 0
+    assert "No breaking changes detected" in output
+    assert "Total files analyzed: 1" in output
+    assert "Unchanged: 1" in output
+
+
+def test_first_token_changed(git_repo):
+    """Test that first token changes are detected as breaking."""
+    initial_content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", initial_content)
+    git_commit(git_repo, "Initial commit")
+
+    updated_content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+securityresources | where type =~ 'microsoft.security/assessments'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", updated_content)
+    git_commit(git_repo, "Update query")
+
+    exit_code, output = run_detector(git_repo, "HEAD~1")
+    assert exit_code == 1
+    assert "1 breaking change(s) detected" in output
+    assert "first_token_changed" in output
+    assert "`resources`" in output
+    assert "`securityresources`" in output
+
+
+def test_file_removed(git_repo):
+    """Test that file removal is detected as breaking."""
+    content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", content)
+    git_commit(git_repo, "Initial commit")
+
+    (git_repo / "data" / "alz-queries" / "checklist" / "test.kql").unlink()
+    git_commit(git_repo, "Remove file")
+
+    exit_code, output = run_detector(git_repo, "HEAD~1")
+    assert exit_code == 1
+    assert "1 breaking change(s) detected" in output
+    assert "removed" in output
+    assert "Files removed: 1" in output
+
+
+def test_file_added(git_repo):
+    """Test that file addition is not breaking."""
+    content1 = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id-1
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test1.kql", content1)
+    git_commit(git_repo, "Initial commit")
+
+    content2 = """// Vendored from https://example.com/blob/def456/query.kql
+// Source checklist ID: test-id-2
+// Vendored at: 2026-01-02T00:00:00Z
+securityresources | where type =~ 'microsoft.security/assessments'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test2.kql", content2)
+    git_commit(git_repo, "Add new query")
+
+    exit_code, output = run_detector(git_repo, "HEAD~1")
+    assert exit_code == 0
+    assert "No breaking changes detected" in output
+    assert "Added: 1" in output
+
+
+def test_header_only_changed(git_repo):
+    """Test that header-only changes are not breaking."""
+    initial_content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", initial_content)
+    git_commit(git_repo, "Initial commit")
+
+    updated_content = """// Vendored from https://example.com/blob/def456/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-02T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", updated_content)
+    git_commit(git_repo, "Update header")
+
+    exit_code, output = run_detector(git_repo, "HEAD~1")
+    assert exit_code == 0
+    assert "No breaking changes detected" in output
+    assert "Header-only changes: 1" in output
+
+
+def test_body_changed_same_token(git_repo):
+    """Test that body changes with same first token are not breaking."""
+    initial_content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", initial_content)
+    git_commit(git_repo, "Initial commit")
+
+    updated_content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines' | where location =~ 'eastus'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", updated_content)
+    git_commit(git_repo, "Update query body")
+
+    exit_code, output = run_detector(git_repo, "HEAD~1")
+    assert exit_code == 0
+    assert "No breaking changes detected" in output
+    assert "Body changes (same token): 1" in output
+
+
+def test_multiple_changes_mixed(git_repo):
+    """Test handling multiple files with mixed change types."""
+    content1 = """// Vendored from https://example.com/blob/abc/query.kql
+// Source checklist ID: test-id-1
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    content2 = """// Vendored from https://example.com/blob/def/query.kql
+// Source checklist ID: test-id-2
+// Vendored at: 2026-01-01T00:00:00Z
+securityresources | where type =~ 'microsoft.security/assessments'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test1.kql", content1)
+    create_kql_file(git_repo, "data/alz-queries/checklist/test2.kql", content2)
+    git_commit(git_repo, "Initial commit")
+
+    updated_content1 = """// Vendored from https://example.com/blob/abc/query.kql
+// Source checklist ID: test-id-1
+// Vendored at: 2026-01-01T00:00:00Z
+policyresources | where type =~ 'microsoft.authorization/policyassignments'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test1.kql", updated_content1)
+    (git_repo / "data" / "alz-queries" / "checklist" / "test2.kql").unlink()
+
+    content3 = """// Vendored from https://example.com/blob/ghi/query.kql
+// Source checklist ID: test-id-3
+// Vendored at: 2026-01-01T00:00:00Z
+authorizationresources | where type =~ 'microsoft.authorization/roleassignments'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test3.kql", content3)
+    git_commit(git_repo, "Mixed changes")
+
+    exit_code, output = run_detector(git_repo, "HEAD~1")
+    assert exit_code == 1
+    assert "2 breaking change(s) detected" in output
+    assert "first_token_changed" in output
+    assert "removed" in output
+    assert "Added: 1" in output
+
+
+def test_json_output(git_repo):
+    """Test JSON output format."""
+    content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", content)
+    git_commit(git_repo, "Initial commit")
+
+    updated_content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+securityresources | where type =~ 'microsoft.security/assessments'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", updated_content)
+    git_commit(git_repo, "Update query")
+
+    exit_code, output = run_detector(git_repo, "HEAD~1", output="json")
+    assert exit_code == 1
+
+    data = json.loads(output)
+    assert data["breaking"] is True
+    assert data["summary"]["breaking"] == 1
+    assert data["summary"]["first_token_changed"] == 1
+    assert len(data["changes"]) == 1
+    assert data["changes"][0]["change_type"] == "first_token_changed"
+    assert data["changes"][0]["base_token"] == "resources"
+    assert data["changes"][0]["head_token"] == "securityresources"
+    assert data["changes"][0]["breaking"] is True
+
+
+def test_markdown_output_format(git_repo):
+    """Test markdown output formatting."""
+    content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", content)
+    git_commit(git_repo, "Initial commit")
+
+    updated_content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+securityresources | where type =~ 'microsoft.security/assessments'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", updated_content)
+    git_commit(git_repo, "Update query")
+
+    exit_code, output = run_detector(git_repo, "HEAD~1", output="markdown")
+    assert exit_code == 1
+    assert "## ALZ Snapshot Breaking-Change Report" in output
+    assert "| File | Change Type | Base Token | Head Token |" in output
+    assert "| `data/alz-queries/checklist/test.kql` |" in output
+    assert "breaking-change-approved" in output
+
+
+def test_no_fail_flag(git_repo):
+    """Test --no-fail flag overrides exit code."""
+    initial_content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", initial_content)
+    git_commit(git_repo, "Initial commit")
+
+    updated_content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+securityresources | where type =~ 'microsoft.security/assessments'
+"""
+    create_kql_file(git_repo, "data/alz-queries/checklist/test.kql", updated_content)
+    git_commit(git_repo, "Update query")
+
+    result = subprocess.run(
+        [
+            "python",
+            str(Path(__file__).parent.parent / "scripts" / "check_breaking_changes.py"),
+            "--base-ref",
+            "HEAD~1",
+            "--no-fail",
+            "--data-dir",
+            "data/alz-queries",
+        ],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0
+    assert "1 breaking change(s) detected" in result.stdout
+
+
+def test_graph_directory_queries(git_repo):
+    """Test detection works for graph/ subdirectory."""
+    content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+ResourceContainers | where type =~ 'microsoft.resources/subscriptions'
+"""
+    create_kql_file(git_repo, "data/alz-queries/graph/test.kql", content)
+    git_commit(git_repo, "Initial commit")
+
+    updated_content = """// Vendored from https://example.com/blob/abc123/query.kql
+// Source checklist ID: test-id
+// Vendored at: 2026-01-01T00:00:00Z
+resources | where type =~ 'microsoft.compute/virtualmachines'
+"""
+    create_kql_file(git_repo, "data/alz-queries/graph/test.kql", updated_content)
+    git_commit(git_repo, "Update query")
+
+    exit_code, output = run_detector(git_repo, "HEAD~1")
+    assert exit_code == 1
+    assert "1 breaking change(s) detected" in output
+    assert "ResourceContainers" in output
+    assert "resources" in output


### PR DESCRIPTION
## Summary

Implements a stdlib-only breaking-change detector for ALZ snapshot refresh PRs. Automatically flags when the first table reference token in a `.kql` file changes (e.g., `resources` → `securityresources`), which signals a schema surface change.

Closes #102.

## Implementation

### Commit 1: `feat(ci): KQL breaking-change detector script`

**File:** `scripts/check_breaking_changes.py`
- Python stdlib only (no external runtime dependencies)
- Compares .kql files between base-ref and head-ref using `git show`
- Extracts first identifier token from first non-comment line
- Categorizes changes:
  - **Breaking**: first token changed, file removed
  - **Non-breaking**: header-only changed, body changed with same token, file added
- Output formats: markdown (PR comment-ready), json (programmatic)
- Exit code: 1 on breaking changes, 0 otherwise (--no-fail flag overrides)

**Tests:** `tests/test_check_breaking_changes.py`
- 11 test cases covering all change types
- Temporary git repo fixture for isolated testing
- Validates markdown and json output formats

### Commit 2: `chore(ci): wire breaking-change detector into refresh PRs`

**File:** `.github/workflows/breaking-change-detector.yml`
- Trigger: PR with changes to `data/alz-queries/**`
- Permissions: `contents: read`, `pull-requests: write`
- Steps:
  1. Checkout with full history (fetch-depth: 0)
  2. Check for `breaking-change-approved` label (skips if present)
  3. Run detector: `--base-ref origin/${{ github.base_ref }} --head-ref HEAD`
  4. Post or update PR comment with report
  5. Fail job on breaking changes (unless override label present)

**Intentionally NOT a required check.** Informational only. Reviewers can override with the `breaking-change-approved` label.

### Commit 3: `docs(alz): document breaking-change detector and override label`

Updated:
- `data/alz-queries/MANIFEST.md` — new "Breaking-change detection" section
- `CHANGELOG.md` — Automation subsection entry
- `CONTRIBUTING.md` — note on breaking-change detection in identifier provenance section

## Acceptance criteria met

✅ Stdlib-based script parsing .kql files and extracting first table reference token
✅ GitHub Actions check on refresh PRs comparing base to head
✅ Breaking changes flagged with PR comment
✅ `breaking-change-approved` label override
✅ Test coverage for sample query changes

## Validation gates passed

All required checks pass locally:

```
✅ ruff check .
✅ ruff format --check .
✅ mypy src
✅ pytest -q (189 passed, 6 skipped)
```

## Design notes

**Why a new workflow instead of extending an existing one?**
- Separation of concerns: refresh-alz-snapshot.yml creates the PR, breaking-change-detector.yml validates it
- Clear trigger: only runs when data/alz-queries/** changes
- Easy to disable independently (not wired into branch protection)

**Why informational rather than required?**
- Legitimate breaking changes do occur (upstream schema updates, deprecated tables)
- Forcing reviewers to apply a label is acceptable friction for schema changes
- Avoids false-positive blocking on intentional updates

**Why first-token-only detection?**
- High signal: table reference changes are almost always breaking
- Low false negative rate: if the table changes, the query surface changed
- Avoids complex KQL parsing (no AST, no regex hell)

## Future enhancements (out of scope for #102)

- Schema migration guide generation (map old → new table)
- Integration with MCP Inspector to validate query executability
- Slack/Teams notification on breaking changes

---

**Ready for review.** Martin to review and merge at your discretion.
