### PR TITLE
docs: reconcile cold-start drift across ADR-001 and runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Reconciled cold-start documentation drift** across ADR-001, runbook, and README to match the 2026-05-15 ADR-001 update (measured 8.5-9.0s baseline, 10s hard regression gate). Removed incorrect "under 2000ms" claim from runbook.md (no source). Updated ADR-001 Principle 6 and decision matrix row to reference canonical Addendum section. Added baseline number to README constraint for clarity.
+
 ### Added
 
 - **Custom governance queries for diagnostics coverage and tag audit** (Closes #100). Two custom queries authored for Management and Resource Organization pillars: (1) `diagnostics_coverage` (8003d59b-f2fc-46c9-b387-d9a889ec491a) reports diagnostic settings coverage by resource type to identify monitoring gaps (category: Management, severity: Medium, tags: diagnostics/monitoring/coverage). (2) `tag_audit` (b8bb32c6-18b1-4563-9435-6cf9b8b24b54) audits required tags (Environment, Owner, CostCenter) to identify tagging compliance gaps (category: Resource Organization, severity: Medium, tags: governance/tagging/compliance). Both queries follow ADR-006 custom-query provenance pattern. Custom query count: 7 (5 IAM from #99 + 2 governance from #100).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Python 3.11+ with FastMCP, per [ADR-001](docs/adr/0001-runtime-choice.md). Build
 
 Constraints:
 
-- Local-first, single binary or single-process startup. Cold-start performance is documented in [docs/perf/coldstart-investigation.md](docs/perf/coldstart-investigation.md).
+- Local-first, single binary or single-process startup. Cold-start performance baseline (measured 8.5-9.0s) and rationale documented in [docs/perf/coldstart-investigation.md](docs/perf/coldstart-investigation.md).
 - Read-only Azure SDK calls only. DefaultAzureCredential exclusively.
 - Zero credentials at rest. Token-scrub on any logging.
 - ALZ checklist queries source from the public `martinopedal/alz-checklist-queries` and `martinopedal/alz-graph-queries` repos (vendored snapshot, pinned by upstream commit SHA).

--- a/docs/adr/0001-runtime-choice.md
+++ b/docs/adr/0001-runtime-choice.md
@@ -15,7 +15,7 @@ We are building an MCP server and Copilot CLI skills bundle for Azure architects
 3. **Vendored ALZ query snapshot.** Source of truth from `martinopedal/alz-checklist-queries` and `martinopedal/alz-graph-queries`. Track upstream commit SHA in snapshot manifest.
 4. **Companion servers stay companions.** We do not proxy or wrap `azure-mcp`. Do not duplicate its tools.
 5. **MCP Inspector compatibility is a CI gate.** All tools must list with valid JSON Schema.
-6. **Cold start under 1 second.** Single binary or single-process startup. No Docker required for local use.
+6. **Cold start is bounded but not aggressively optimized.** Single binary or single-process startup. No Docker required for local use. Hard regression gate: 10 seconds. See Addendum (2026-05-15 update) for measured baseline and rationale.
 
 ### Why This Decision Matters Now
 
@@ -109,7 +109,7 @@ Supported. C# SDK ships with inspector-compatible tool listings. CI gate passes.
 |-----------|--------|--------|------------|------|-------|
 | MCP SDK Maturity | 3 | 9 | 9 | 9 | All Tier 1 with Linux Foundation (Python, TS) or Microsoft (.NET) backing |
 | Azure SDK Quality | 4 | 8 | 7 | 10 | .NET is gold standard. Python is mature. TypeScript is solid. |
-| Cold Start (<1s) | 5 | 9 | 8 | 7 | Python 200-800ms, TS 300-700ms, .NET 300-1500ms (optimized: <500ms) |
+| Cold Start (<1s)* | 5 | 9 | 8 | 7 | Python 200-800ms, TS 300-700ms, .NET 300-1500ms (optimized: <500ms). *See Addendum (2026-05-15) for revised baseline measurement. |
 | Install/Distribution | 3 | 8 | 9 | 8 | uvx, npx, dotnet tool all work. npx is ephemeral-first. |
 | JSON Schema Tooling | 3 | 8 | 9 | 8 | All have validation and generation. TS has best type-to-schema flow. |
 | Ecosystem Fit | 2 | 9 | 7 | 6 | Python is dominant in ops/data. TS is web/cloud. .NET is enterprise. |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -112,7 +112,7 @@ az login --tenant <your-tenant-id>
 
 **Root cause:** Python startup time + import graph (measured baseline in ADR-001).
 
-**Fix:** None required. This is expected per ADR-001 cold-start budget (under 2000ms hard gate). Use MCP clients' caching (e.g., Claude Desktop caches results across conversations). If unacceptable, see [docs/perf/coldstart-investigation.md](perf/coldstart-investigation.md) for profiling instructions.
+**Fix:** None required. This is expected per ADR-001 (measured baseline 8.5-9.0s, hard regression gate 10s, see ADR-001 Addendum 2026-05-15). Use MCP clients' caching (e.g., Claude Desktop caches results across conversations). If unacceptable, see [docs/perf/coldstart-investigation.md](perf/coldstart-investigation.md) for profiling instructions.
 
 ### 6. MCP client says "tool not found"
 


### PR DESCRIPTION
## Summary

Reconciles four different cold-start numbers across public docs into one coherent narrative matching the canonical 2026-05-15 ADR-001 update.

## Changes

- **ADR-001 line 18 (Principle 6):** Updated from 'under 1 second' to 'bounded but not aggressively optimized' with reference to Addendum (2026-05-15 update)
- **ADR-001 line 112 (decision matrix):** Added footnote on '<1s' row linking to Addendum. Comparative scoring remains useful for runtime selection; absolute target revised.
- **runbook.md line 115:** Removed incorrect 'under 2000ms hard gate' claim (no source). Replaced with accurate ADR-001 reference: measured baseline 8.5-9.0s, hard regression gate 10s.
- **README.md line 56:** Added baseline number (8.5-9.0s) to cold-start performance constraint for clarity.
- **CHANGELOG.md:** Added Unreleased / Documentation entry.

## Architectural decision

Amend ADR-001 in place. The 2026-05-15 Addendum already contains the canonical position (measured 8.5-9.0s baseline, 10s hard regression gate, 6-7s soft target after lazy-import wins). The drift was in older sections that weren't updated when the architectural position was revised. A new ADR-007 would fragment the runtime-choice decision unnecessarily.

## Gates

✅ ruff lint: All checks passed (exit 0)
✅ ruff format: 34 files already formatted (exit 0)
✅ mypy: Success: no issues found in 9 source files (exit 0)
✅ pytest: 207 passed, 5 skipped, 1 warning in 29.27s (exit 0)

## Scope

Documentation-only change. No code changes. No tracking issue (housekeeping reconciliation identified during Wave 13 planning).

/cc @martinopedal (Coordinator) for admin-toggle merge after CI passes.

---
_This PR reconciles documentation drift. The canonical cold-start position has been ADR-001 Addendum (2026-05-15) since that date; this PR updates the older sections that lagged behind._