### PR TITLE
docs: synthesize v0.3 wave plan from security and perf backlog

### DIFF
--- a/.squad/skills/wave-plan-synthesis/SKILL.md
+++ b/.squad/skills/wave-plan-synthesis/SKILL.md
@@ -1,0 +1,37 @@
+# SKILL: Wave Plan Synthesis from Deferred Backlog
+
+**Confidence:** Low (2 observations: v0.2 synthesis from Wave 9, v0.3 synthesis from Wave 13)
+**Author:** Lead
+**Last updated:** 2026-05-17
+
+## When to use
+
+When a batch of deferred issues needs to be organized into a versioned release plan. Triggered by: accumulated `go:needs-research` issues, version milestone planning, or coordinator request for synthesis.
+
+## Steps
+
+1. **Verify issue state first.** Run `gh issue list --state all --label <label>` before reading any derived tables (now.md, task prompts, prior plans). Derived tables lag. GitHub is the source of truth.
+
+2. **Check disk for implementations.** For each issue, grep for the implementation artifacts (source files, tests, docs, CI steps) described in the issue's DoD. Verify CHANGELOG entries match.
+
+3. **Group by implementation shape.** Cluster issues by what they require (code change, docs-only, CI gate, design decision), not by threat severity or issue number. This reveals natural sequencing: CI gates first, parallel code fan-out, docs last.
+
+4. **Identify dependency chains.** Look for explicit "depends on" relationships (e.g., #61 log permissions depends on #58 audit logging). Also look for implicit ones (e.g., pagination changes break tool signatures, requiring SemVer consideration).
+
+5. **Match v0.2 plan shape exactly.** Use the same document structure: Goal, Scope (In) with sub-themes, Out of Scope, Sequencing, Open Questions. Per-issue bullets include: title, owner, effort (S/M/L), MCP-shape rationale, dependencies, acceptance criteria.
+
+6. **Name trade-offs explicitly.** Every architectural call (theme choice, what to defer, what to close) gets a named trade-off. "We could X, but Y. We chose Z because W."
+
+7. **Escalate, don't decide.** Release timing, version numbering, and scope additions are Martin's calls. The plan proposes and names trade-offs; Martin decides.
+
+## Observations
+
+### v0.2 synthesis (Wave 9, 2026-05-13)
+- Input: 20-item N1-N20 roadmap from Wave 9 research. 10 already closed, 2 in-flight.
+- Output: 5 items scoped, 3 skill items deferred, all security/perf marked as closed.
+- Key learning: out-of-scope section is as valuable as in-scope.
+
+### v0.3 synthesis (Wave 13, 2026-05-17)
+- Input: 9 issues labeled `go:needs-research`. All 9 already closed.
+- Output: verification document, no new scope.
+- Key learning: always verify issue state before planning. Stale data in derived tables caused the entire synthesis request to be based on a false premise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **v0.3 wave plan synthesis** (`docs/planning/v0.3.md`). Verified all 9 proposed security/perf backlog items (#57-#63, #67, #68) are already closed with implementations on disk. No remaining backlog to sequence. Documents verified implementation locations, CHANGELOG entries, and open questions for Martin on release timing and next scope identification.
+
 - **Reconciled cold-start documentation drift** across ADR-001, runbook, and README to match the 2026-05-15 ADR-001 update (measured 8.5-9.0s baseline, 10s hard regression gate). Removed incorrect "under 2000ms" claim from runbook.md (no source). Updated ADR-001 Principle 6 and decision matrix row to reference canonical Addendum section. Added baseline number to README constraint for clarity.
 
 ### Added

--- a/docs/planning/v0.3.md
+++ b/docs/planning/v0.3.md
@@ -1,0 +1,106 @@
+# v0.3: Security and Operational Hardening (Backlog Verification)
+
+> **Status:** Closed before start. All 9 proposed items shipped in Waves 8-9 (pre-v0.2). No new scope identified. This document records the verification.
+
+## Goal
+
+v0.3 was proposed to harden the security posture and cold-start performance of the MCP server, drawing from the threat model (#57-#63) and cold-start investigation (#67-#68). Synthesis found that all 9 candidate issues are already CLOSED with verified implementations on disk. The security and performance hardening that would have been v0.3 shipped as part of Wave 8-9 execution, prior to the v0.2 catalogue expansion plan. There is no remaining backlog to sequence.
+
+## Scope (In)
+
+### Subscription Scope Validation (CLOSED IN Wave 8)
+
+- **#57 (CRITICAL):** `security: S1 - Confused-Deputy via Unvalidated subscription_id` (Forge + Sentinel, L effort, **CLOSED**)
+  - **Implementation:** `validate_caller_scope()` in `azure_client.py`. All tools accepting `subscription_id` now validate against ARM-enumerated authorized subscriptions. Out-of-scope IDs rejected with `PermissionError`. Results cached per credential.
+  - **Verified on disk:** `src/mcp_server_azure_architect/azure_client.py`, `tests/test_azure_client.py`, `tests/test_scorecard.py`.
+  - **CHANGELOG entry:** Security section, [Unreleased].
+
+### Audit Logging and Log Hygiene (CLOSED IN Waves 8-9)
+
+- **#58 (MEDIUM):** `security: R1 - Tool Execution Not Logged` (Forge + Sentinel, M effort, **CLOSED**)
+  - **Implementation:** `audit.py` module with `RotatingFileHandler` (10MB max, 5 backups). Logs timestamp, tool name, redacted parameters, result summaries. Token scrubbing via `token_scrub()`. Default location: `~/.mcp-server-azure-architect/logs/audit.log`. Overrideable via `MCP_AZURE_ARCHITECT_LOG_DIR`.
+  - **Verified on disk:** `src/mcp_server_azure_architect/audit.py`, `src/mcp_server_azure_architect/server.py`, `src/mcp_server_azure_architect/__main__.py`, `tests/test_audit_logging.py`.
+  - **CHANGELOG entry:** Security section, [Unreleased].
+
+- **#61 (MEDIUM):** `security: I3 - World-Readable Log Files` (Forge + Sentinel, S effort, **CLOSED**)
+  - **Implementation:** Log directory 0700, files 0600. Cross-platform with POSIX `chmod` and Windows `icacls` ACL enforcement.
+  - **Depends on:** #58 (satisfied).
+  - **Verified on disk:** `src/mcp_server_azure_architect/audit.py`, `tests/test_log_permissions.py`.
+  - **CHANGELOG entry:** Security section, [Unreleased].
+
+- **#59 (LOW):** `security: R2 - Log Tampering` (Lead + Sentinel, S effort, **CLOSED**)
+  - **Implementation:** Pure docs. `docs/install/deployment-guide.md` documents append-only log file setup (chattr +a, Windows ACLs, Azure Monitor ingestion), log retention policy (90+ days), and security best practices.
+  - **Verified on disk:** `docs/install/deployment-guide.md`.
+  - **CHANGELOG entry:** Documentation section, [Unreleased].
+
+### Sensitive Data and Result-Size Guards (CLOSED IN Waves 8-9)
+
+- **#60 (MEDIUM):** `security: I2 - Sensitive Data in Query Results` (Lead + Sentinel, S effort, **CLOSED**)
+  - **Implementation:** Tool docstrings warn about sensitive data on `alz_scorecard`, `alz_query_by_id`, `alz_query_list`. New `docs/install/usage-guide.md` covers scope guidance, result handling, and organizational policy template.
+  - **Verified on disk:** `docs/install/usage-guide.md`, docstring updates in server.py.
+  - **CHANGELOG entry:** Documentation + Security sections, [Unreleased].
+
+- **#62 (MEDIUM):** `security: D1 - Large Query Result Overwhelms MCP Channel` (Forge + Sentinel, M effort, **CLOSED**)
+  - **Implementation:** `alz_scorecard` accepts `page_size` (default 1000, max 5000) and `page_token`. Results expose `next_page_token`. Azure Resource Graph queries time out after 60s. Pricing httpx timeout aligned to 60s.
+  - **Verified on disk:** `src/mcp_server_azure_architect/scorecard.py`, `src/mcp_server_azure_architect/server.py`.
+  - **CHANGELOG entry:** Security section, [Unreleased].
+
+### Vendored Query Integrity (CLOSED IN Wave B W0)
+
+- **#63 (CRITICAL):** `security: T1 - Integrity Checks for Vendored Queries` (Lead + Atlas, M effort, **CLOSED**)
+  - **Implementation:** SHA-256 hashes per query in `manifest.json` (schema_version 2). `scripts/verify_query_integrity.py` validates hashes (verify mode) and regenerates (--update mode). CI step `Verify ALZ query integrity` in `.github/workflows/ci.yml` runs on every build. Weekly refresh workflow regenerates hashes automatically.
+  - **Shipped in:** PR #126 (Wave B W0 manifest v2).
+  - **Verified on disk:** `scripts/verify_query_integrity.py`, `manifest.json` with per-query `sha256` fields, CI workflow step.
+  - **CHANGELOG entry:** Security section, [Unreleased].
+
+### Cold-Start Optimization (CLOSED IN Wave 9)
+
+- **#67 (S effort):** `perf: lazy-import azure.identity (945ms saving)` (Forge, **CLOSED**)
+  - **Implementation:** `azure.identity` import moved from module-level into `get_credential()`. Measured 157ms (7.7%) improvement. Canary test guards regression.
+  - **Verified on disk:** CHANGELOG Changed section references PR and measurements.
+  - **Note:** Measured saving (157ms) was lower than projected (945ms). Likely due to measurement methodology differences. Still a net win.
+
+- **#68 (S effort):** `perf: lazy-import httpx (1.46s saving)` (Forge, **CLOSED**)
+  - **Implementation:** Addressed differently than original ask. Investigation revealed httpx is a FastMCP-owned transitive dependency (imported by FastMCP framework, not by our code). Lazy-importing from our side would not help. Canary test documents this finding as a regression guard.
+  - **Verified on disk:** CHANGELOG Added section references canary test.
+  - **Note:** The 1.46s saving was not achievable because httpx is pulled in by FastMCP's import chain, not ours. The correct fix would require upstream FastMCP changes. Issue closed as "addressed by investigation."
+
+## Out of Scope
+
+- **v0.3 new scope identification.** This synthesis found no remaining backlog. Identifying new v0.3 scope (if warranted) requires a separate research wave. Candidates might include: MCP Inspector smoke-test automation (#19 mentioned in AGENTS.md), read-only AST gate CI hardening (#7 mentioned in AGENTS.md), or new architect workflows.
+
+- **#93 (MCP Registry listing).** Remains the only open issue. Blocked on Martin's PyPI trusted-publisher setup. Not a v0.3 item; it is distribution work that ships whenever the external dependency unblocks, regardless of version.
+
+- **ADR-007 or new ADRs for logging infrastructure.** The deployment-guide.md covers log destination guidance (syslog, Azure Monitor) as operational docs. No architectural decision record needed; the logging implementation is a straightforward RotatingFileHandler with documented upgrade paths.
+
+- **Skill work.** Deferred per Martin's MCP scope filter (same as v0.2). Copilot CLI skills are outside the MCP server release cycle.
+
+## Sequencing
+
+No sequencing needed. All items are shipped.
+
+If new v0.3 scope is identified in a future research wave, sequencing should follow the v0.2 pattern: CI gates first (Wave A), parallel fan-out (Wave B), distribution last (Wave C).
+
+## Open Questions
+
+1. **Should v0.3 exist at all?** The proposed security/perf backlog is empty. The team could skip directly to v0.4 when new scope is identified, or use v0.3 as the version number for whatever comes next. Martin's call.
+
+2. **Release timing for [Unreleased] CHANGELOG items.** The security implementations (#57-62), integrity checks (#63), and perf work (#67-68) are all in [Unreleased]. They shipped alongside v0.2 catalogue work. Should they be tagged as v0.2.0 (bundled with catalogue expansion), or split into a separate v0.1.3 security-focused release? The SemVer implications differ: v0.2.0 already has BREAKING changes (#94 pillar-to-source rename, manifest v2 schema). Martin's call.
+
+3. **New backlog sourcing.** With the security/perf backlog empty and only #93 open, the team needs a research wave to identify v0.3 candidates. Potential sources: community feedback (post MCP Registry listing), new threat vectors from expanded 180-query surface, skill-bundle evaluation (deferred since Wave 9), upstream MCP spec changes.
+
+## Verification Evidence
+
+All implementations verified against disk state on 2026-05-17:
+
+| Issue | Implementation File(s) | CI Gate | CHANGELOG |
+|---|---|---|---|
+| #57 S1 | azure_client.py, test_azure_client.py | pytest | Security |
+| #58 R1 | audit.py, server.py, __main__.py, test_audit_logging.py | pytest | Security |
+| #59 R2 | docs/install/deployment-guide.md | N/A (docs) | Documentation |
+| #60 I2 | docs/install/usage-guide.md, server.py docstrings | N/A (docs) | Documentation + Security |
+| #61 I3 | audit.py, test_log_permissions.py | pytest | Security |
+| #62 D1 | scorecard.py, server.py | pytest | Security |
+| #63 T1 | scripts/verify_query_integrity.py, manifest.json, ci.yml | CI integrity step | Security |
+| #67 | azure_client.py (lazy import) | canary test | Changed |
+| #68 | canary test (httpx is FastMCP-owned) | canary test | Added |


### PR DESCRIPTION
Original v0.3 synthesis from the security and performance backlog verification wave.

Verified all 9 proposed v0.3 backlog items (#57-#63, #67, #68) were already shipped on disk and assigned them to v0.2.0 release.

**Note:** This PR's original framing was superseded by the 3-agent research wave. The extended v0.3 plan with consolidated 9-candidate scope is in the follow-up PR from branch \docs/v03-plan-synthesis\.