### PR TITLE
fix(release): tag-pin pypa/gh-action-pypi-publish to v1.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,11 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d  # v1.14.0
+        # Tag pin (not SHA pin) is intentional: pypa/gh-action-pypi-publish pulls its
+        # ghcr.io runtime image using the ref it was invoked with as the image tag,
+        # and version-tagged images are published while SHA-tagged images are not.
+        # See pypa/gh-action-pypi-publish#290 for the upstream behaviour.
+        uses: pypa/gh-action-pypi-publish@v1.14.0
 
   create-release:
     name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`release.yml` PyPI publish step now tag-pins `pypa/gh-action-pypi-publish` to `v1.14.0` instead of SHA-pinning.** The action pulls its runtime image from `ghcr.io/pypa/gh-action-pypi-publish:<ref>` using the exact ref the workflow invoked it with. SHA-tagged images are not published by upstream maintainers, only version-tagged images are, so SHA pins fail with `manifest unknown`. Confirmed against ghcr.io: `:v1.14.0` exists, `:<sha>` does not. See pypa/gh-action-pypi-publish#290 for the upstream behaviour. Discovered when the v0.2.0 tag push failed in the publish-pypi job.
+
 ## [0.2.0] - 2026-05-13
 
 ### Added


### PR DESCRIPTION
## What

Tag-pin `pypa/gh-action-pypi-publish` to `v1.14.0` instead of SHA-pinning. The v0.2.0 tag push failed in 6 seconds at the `publish-pypi` step because the action pulls its runtime image from `ghcr.io/pypa/gh-action-pypi-publish` using the ref it was invoked with, and **only version-tagged images are published** by the upstream maintainers, not SHA-tagged ones.

## Why

| Tag | ghcr.io status |
|---|---|
| `:v1.14.0` | 200 OK |
| `:v1.13.0` | 200 OK |
| `:release-v1` | 200 OK |
| `:<sha>` | `manifest unknown` |

This matches pypa/gh-action-pypi-publish#290 (closed Nov 2024 with maintainer acknowledgement). Inline comment in release.yml documents the rationale so a future contributor doesn't re-pin to SHA chasing an OpenSSF Scorecard finding.

## After this merges

Re-tag and re-push v0.2.0 at the new HEAD. The first failed run did NOT publish anything to PyPI (failed before upload), so retry is safe.