### PR TITLE
chore(ci): route hosted-runner workflows to Pool P1

### DIFF
--- a/.github/workflows/breaking-change-detector.yml
+++ b/.github/workflows/breaking-change-detector.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   detect:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - name: Checkout code with full history
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: pytest -v
 
   inspector-smoke:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     
     steps:
       - name: Checkout code

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4.5.0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/readonly-check.yml
+++ b/.github/workflows/readonly-check.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   readonly-check:
     name: Check for mutation methods
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     
     steps:
       - name: Checkout code

--- a/.github/workflows/refresh-alz-snapshot.yml
+++ b/.github/workflows/refresh-alz-snapshot.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   verify-version:
     name: Verify tag matches pyproject.toml version
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     outputs:
       version: ${{ steps.get-version.outputs.version }}
       tag: ${{ steps.get-tag.outputs.tag }}
@@ -74,7 +74,7 @@ jobs:
   build:
     name: Build distribution packages
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -100,7 +100,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     environment:
       name: pypi
       url: https://pypi.org/p/mcp-server-azure-architect
@@ -123,7 +123,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     needs: [verify-version, publish-pypi]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     permissions:
       contents: write
     steps:
@@ -161,7 +161,7 @@ jobs:
   publish-mcp-registry:
     name: Publish to MCP Registry
     needs: [verify-version, publish-pypi]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   heartbeat:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -12,7 +12,7 @@ jobs:
   assign-work:
     # Only trigger on squad:{member} labels (not the base "squad" label)
     if: startsWith(github.event.label.name, 'squad:')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   triage:
     if: github.event.label.name == 'squad'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   sync-labels:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, linux, x64]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Route this repo's GitHub-hosted ubuntu workflows onto **Pool P1** (personal-scope KEDA-scaled ACA Linux runners). Mechanical change, no workflow logic touched.

```diff
- runs-on: ubuntu-latest
+ runs-on: [self-hosted, personal, linux, x64]
```

## Files changed (12)

- `breaking-change-detector.yml:1` line(s)
- `ci.yml:1` line(s)
- `codeql.yml:1` line(s)
- `dependency-review.yml:1` line(s)
- `gitleaks.yml:1` line(s)
- `readonly-check.yml:1` line(s)
- `refresh-alz-snapshot.yml:1` line(s)
- `release.yml:5` line(s)
- `squad-heartbeat.yml:1` line(s)
- `squad-issue-assign.yml:1` line(s)
- `squad-triage.yml:1` line(s)
- `sync-squad-labels.yml:1` line(s)

Total `runs-on:` lines rewritten: **16**

## Why

Pool P1 deployed via `martinopedal/personal-runners-infra`. Canonical label set per ADR-0033 in `alz-avm-tf-demo/.squad/decisions.md`:

```
[self-hosted, personal, linux, x64]
```

We pay for GitHub-hosted minutes; routing personal repos to P1 reclaims that spend. KEDA scales runners from zero on queued jobs (~30-60s cold start).

## Validation

Next scheduled run of each workflow exercises P1 end-to-end. If a workflow stays queued >5 min, fall back: temporarily revert that file to `ubuntu-latest` and file an issue against `personal-runners-infra`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
