### PR TITLE
docs: clarify skill bundle deferral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,8 @@ Ship an MCP server + Copilot CLI skills bundle that fills the architect-shaped g
 - Ruff lint and format clean.
 - Mypy type check passes.
 - Pytest unit tests pass (Python 3.11, 3.12).
-- MCP Inspector smoke test: server starts, all tools enumerate with valid JSON Schema (Forge issue #19 forthcoming).
-- Read-only AST gate enforced: no Azure SDK `Begin*`, `Create*`, `Update*`, or `Delete*` calls in the call graph (Sentinel issue #7 forthcoming).
+- MCP Inspector smoke test: server starts, all tools enumerate with valid JSON Schema (Forge issue #19).
+- Read-only AST gate enforced: no Azure SDK `Begin*`, `Create*`, `Update*`, or `Delete*` calls in the call graph (Sentinel issue #7).
 - gitleaks scan passes (no embedded secrets).
 - CodeQL scan passes (security analysis).
 - Dependency-review check passes (supply chain).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- Clarified that the architect-specific Copilot CLI skill bundle is post-v0.2 deferred work, and removed stale "forthcoming" wording from implemented validation gates.
+
 ### Fixed
 
 - **`release.yml` PyPI publish step now tag-pins `pypa/gh-action-pypi-publish` to `v1.14.0` instead of SHA-pinning.** The action pulls its runtime image from `ghcr.io/pypa/gh-action-pypi-publish:<ref>` using the exact ref the workflow invoked it with. SHA-tagged images are not published by upstream maintainers, only version-tagged images are, so SHA pins fail with `manifest unknown`. Confirmed against ghcr.io: `:v1.14.0` exists, `:<sha>` does not. See pypa/gh-action-pypi-publish#290 for the upstream behaviour. Discovered when the v0.2.0 tag push failed in the publish-pypi job.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This server is **not a router or aggregator**. MCP clients already aggregate. We
 - A curated `mcp-config.json` for Copilot CLI, Claude Desktop, Cursor, and VS Code Copilot.
 - Read-only by default, end to end.
 
+The architect-specific Copilot CLI skill bundle is planned post-v0.2 work. The current release delivers the MCP server and companion client configuration, while the skill bundle remains tracked as future scope.
+
 ## What's out of scope
 
 - Wrapping or proxying `azure-mcp`. Anything `azure-mcp` already exposes (raw KQL/ARG, quota, advisor, monitor, policy, RBAC, AKS, App Service) is **explicitly out**.


### PR DESCRIPTION
## Summary

Clarifies that the architect-specific Copilot CLI skill bundle is deferred beyond v0.2, and removes stale forthcoming wording from implemented validation gates.

AI-assisted contribution: created with OpenAI GPT-5.

## Related issue

Closes #142

## Changes

- Add a README note that the skill bundle is post-v0.2 deferred work.
- Remove stale "forthcoming" wording from the AGENTS.md validation gate references for issues #19 and #7.
- Add an Unreleased changelog entry under Documentation.

## Validation gates

Before opening this PR, confirm:

- [x] `.venv/bin/python -m pytest -q` passes with `.venv/bin` on PATH: 211 passed, 1 skipped.
- [x] `.venv/bin/python -m ruff check .` is clean.
- [ ] `.venv/bin/python -m mypy src tests scripts` is clean. Existing unrelated type errors are present in tests/scripts on Python 3.14 with current dependency resolution; `.venv/bin/python -m mypy src` passes.
- [x] `python scripts/check_readonly.py src/mcp_server_azure_architect/` is not applicable because `src/` was not modified.
- [x] `python scripts/mcp_smoke.py` is not applicable because tools did not change.
- [x] New query tools have sensitive-data warning in docstring: not applicable, no query tools changed.
- [x] CHANGELOG.md updated under `[Unreleased]`.
- [x] `git diff --check` passes.

## ADR or design notes

No ADR changes.

## Squad reviewer

Docs scope, suitable for `squad:sage`.

